### PR TITLE
fix(server): auth on /ipc-request + timing-safe token comparison

### DIFF
--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -1918,7 +1918,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   }
 
   async function callPocodexIpc(method: string, params?: unknown): Promise<unknown> {
-    const response = await nativeFetch("/ipc-request", {
+    const response = await nativeFetch(getIpcRequestUrl(getStoredToken()), {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -3040,6 +3040,10 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     return url.toString();
   }
 
+  function getIpcRequestUrl(token: string): string {
+    return token ? `/ipc-request?token=${encodeURIComponent(token)}` : "/ipc-request";
+  }
+
   function getSessionCheckUrl(token: string): string {
     const url = new URL(SESSION_CHECK_PATH, window.location.href);
     if (token) {
@@ -3549,7 +3553,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
         init?.method ??
         (input instanceof Request ? (input as Request & { method?: string }).method : undefined) ??
         "POST";
-      return nativeFetch("/ipc-request", {
+      return nativeFetch(getIpcRequestUrl(getStoredToken()), {
         method,
         body: init?.body,
         headers: init?.headers,

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -8,7 +8,7 @@ import type { AddressInfo } from "node:net";
 import { resolve, sep } from "node:path";
 import { readFile } from "node:fs/promises";
 import type { Duplex } from "node:stream";
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 
 import mimeTypes from "mime-types";
 import { WebSocket, WebSocketServer } from "ws";
@@ -225,6 +225,12 @@ export class PocodexServer {
     }
 
     if (url.pathname === "/ipc-request") {
+      if (!this.isAuthorized(url.searchParams.get("token"))) {
+        response.statusCode = 401;
+        response.setHeader("Content-Type", "application/json; charset=utf-8");
+        response.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
       await this.handleIpcRequest(request, response);
       return;
     }
@@ -316,7 +322,15 @@ export class PocodexServer {
   }
 
   private isAuthorized(requestToken: string | null): boolean {
-    return this.options.token.length === 0 || requestToken === this.options.token;
+    if (this.options.token.length === 0) {
+      return true;
+    }
+    if (!requestToken) {
+      return false;
+    }
+    const expected = Buffer.from(this.options.token);
+    const actual = Buffer.from(requestToken);
+    return expected.length === actual.length && timingSafeEqual(expected, actual);
   }
 
   private async handleSocketMessage(session: BrowserSession, raw: string): Promise<void> {

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -1235,7 +1235,7 @@ describe("renderBootstrapScript", () => {
     });
 
     expect(fetchCalls.at(-1)).toEqual({
-      input: "/ipc-request",
+      input: "/ipc-request?token=secret",
       init: {
         method: "POST",
         body: '{"method":"ping"}',

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -693,7 +693,7 @@ describe("PocodexServer", () => {
     const { server, relay, url } = await createTestServer();
     servers.push(server);
 
-    const response = await fetch(`${url}/ipc-request`, {
+    const response = await fetch(`${url}/ipc-request?token=secret`, {
       method: "POST",
       headers: {
         "content-type": "application/json",


### PR DESCRIPTION
Fixes #10

## Summary
- Add token auth check to the `/ipc-request` endpoint, matching the behavior of `/session-check` and the WebSocket `/session` upgrade
- Switch token comparison from `===` to `crypto.timingSafeEqual`
- Update the browser bootstrap to pass the stored token on IPC requests

## Test plan
- All existing tests updated and passing
- Verified `/ipc-request` returns 401 when token is configured but not provided
- Verified `/ipc-request` works normally when no token is configured (empty token = no auth, unchanged)