### PR TITLE
Fix: restore git branch switching from Codex

### DIFF
--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -166,6 +166,28 @@ interface GitRepositoryInfo {
   originUrl: string | null;
 }
 
+interface GitCheckoutBranchRequest {
+  cwd: string;
+  branch: string;
+}
+
+interface GitCheckoutBranchResponse {
+  status: "success" | "error";
+  error?: string;
+  errorType?: "blocked-by-working-tree-changes";
+  conflictedPaths?: string[];
+  execOutput?: {
+    command: string;
+    output: string;
+  };
+}
+
+interface ExecCommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
 interface GitOriginsResponse {
   origins: GitOriginRecord[];
   homeDir: string;
@@ -1740,6 +1762,20 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     const url = new URL(rawUrl);
     const path = url.pathname.replace(/^\/+/, "");
     switch (path) {
+      case "git-checkout-branch":
+        try {
+          return {
+            status: 200,
+            body: await this.handleGitCheckoutBranchRequest(body),
+          };
+        } catch (error) {
+          return {
+            status: 400,
+            body: {
+              error: normalizeError(error).message,
+            },
+          };
+        }
       case "apply-patch":
         try {
           return {
@@ -2001,6 +2037,38 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       default:
         return null;
     }
+  }
+
+  private async handleGitCheckoutBranchRequest(body: unknown): Promise<GitCheckoutBranchResponse> {
+    const request = readGitCheckoutBranchRequest(body);
+    const cwd = resolve(request.cwd);
+    const args = ["checkout", "--quiet", request.branch];
+    const command = `git ${args.join(" ")}`;
+    const result = await execGitCommand(cwd, args);
+    if (result.ok) {
+      return {
+        status: "success",
+      };
+    }
+
+    const conflictedPaths = parseGitCheckoutBlockedPaths(result.stderr);
+    const execOutput = buildExecOutput(command, result.stdout, result.stderr);
+    const response: GitCheckoutBranchResponse = {
+      status: "error",
+      error:
+        conflictedPaths.length > 0
+          ? "Your working tree has changes that would be overwritten by checkout."
+          : readGitCheckoutErrorMessage(result.stderr),
+    };
+    if (conflictedPaths.length > 0) {
+      response.errorType = "blocked-by-working-tree-changes";
+      response.conflictedPaths = conflictedPaths;
+    }
+    if (execOutput) {
+      response.execOutput = execOutput;
+    }
+
+    return response;
   }
 
   private async handleRelativeFetchRequest(
@@ -3787,7 +3855,15 @@ function readGitOriginDirectories(body: unknown): string[] {
 }
 
 async function runGitCommand(cwd: string, args: string[]): Promise<string> {
-  return new Promise<string>((resolveOutput, reject) => {
+  const result = await execGitCommand(cwd, args);
+  if (!result.ok) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed.`);
+  }
+  return result.stdout;
+}
+
+async function execGitCommand(cwd: string, args: string[]): Promise<ExecCommandResult> {
+  return new Promise((resolveResult) => {
     execFile(
       "git",
       args,
@@ -3796,15 +3872,102 @@ async function runGitCommand(cwd: string, args: string[]): Promise<string> {
         encoding: "utf8",
         maxBuffer: 1024 * 1024,
       },
-      (error, stdout) => {
+      (error, stdout, stderr) => {
+        const trimmedStdout = stdout.trim();
+        const trimmedStderr = stderr.trim();
         if (error) {
-          reject(error);
+          resolveResult({
+            ok: false,
+            stdout: trimmedStdout,
+            stderr: trimmedStderr || normalizeError(error).message,
+          });
           return;
         }
-        resolveOutput(stdout.trim());
+
+        resolveResult({
+          ok: true,
+          stdout: trimmedStdout,
+          stderr: trimmedStderr,
+        });
       },
     );
   });
+}
+
+function parseGitCheckoutBlockedPaths(stderr: string): string[] {
+  const lines = stderr.split(/\r?\n/);
+  const markerIndex = lines.findIndex((line) =>
+    /would be overwritten by checkout:?$/i.test(line.trim()),
+  );
+  if (markerIndex < 0) {
+    return [];
+  }
+
+  const conflictedPaths: string[] = [];
+  for (const line of lines.slice(markerIndex + 1)) {
+    if (!/^\s+/.test(line)) {
+      break;
+    }
+
+    const path = line.trim();
+    if (path.length > 0) {
+      conflictedPaths.push(path);
+    }
+  }
+
+  return uniqueStrings(conflictedPaths);
+}
+
+function readGitCheckoutErrorMessage(stderr: string): string {
+  const firstLine = stderr
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^(error|fatal):\s*/i, "").trim())
+    .find((line) => line.length > 0 && line.toLowerCase() !== "aborting");
+  return firstLine ?? "Failed to switch branch.";
+}
+
+function buildExecOutput(
+  command: string,
+  stdout: string,
+  stderr: string,
+): { command: string; output: string } | null {
+  const output = [stdout, stderr].filter((value) => value.trim().length > 0).join("\n\n");
+  if (output.length === 0) {
+    return null;
+  }
+
+  return {
+    command,
+    output,
+  };
+}
+
+function readGitCheckoutBranchRequest(body: unknown): GitCheckoutBranchRequest {
+  const params = readCodexFetchParams(body);
+  if (!isJsonRecord(params)) {
+    throw new Error("Checkout params are required.");
+  }
+
+  const cwd =
+    typeof params.cwd === "string"
+      ? params.cwd.trim()
+      : typeof params.root === "string"
+        ? params.root.trim()
+        : "";
+  const branch =
+    typeof params.branch === "string"
+      ? params.branch.trim()
+      : typeof params.branchName === "string"
+        ? params.branchName.trim()
+        : "";
+  if (cwd.length === 0) {
+    throw new Error("Checkout cwd is required.");
+  }
+  if (branch.length === 0) {
+    throw new Error("Checkout branch is required.");
+  }
+
+  return { cwd, branch };
 }
 
 async function execGhCommand(

--- a/test/app-server-bridge-git-checkout.test.ts
+++ b/test/app-server-bridge-git-checkout.test.ts
@@ -1,0 +1,152 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import {
+  describeAppServerBridge,
+  createBridge,
+  getFetchResponse,
+  getFetchJsonBody,
+  tempDirs,
+  waitForCondition,
+} from "./support/app-server-bridge-test-kit.js";
+
+describeAppServerBridge(({ children }) => {
+  it("checks out a branch for codex host fetch requests", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-git-checkout-"));
+    tempDirs.push(tempDirectory);
+    const { repoRoot, branchName } = await createGitCheckoutFixture(tempDirectory);
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-git-checkout-branch",
+      method: "POST",
+      url: "vscode://codex/git-checkout-branch",
+      body: JSON.stringify({
+        cwd: repoRoot,
+        branch: branchName,
+        hostId: "local",
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-git-checkout-branch")),
+    );
+
+    expect(getFetchResponse(emittedMessages, "fetch-git-checkout-branch")).toMatchObject({
+      type: "fetch-response",
+      requestId: "fetch-git-checkout-branch",
+      responseType: "success",
+      status: 200,
+    });
+    expect(getFetchJsonBody(emittedMessages, "fetch-git-checkout-branch")).toEqual({
+      status: "success",
+    });
+    expect(await readCurrentBranch(repoRoot)).toBe(branchName);
+
+    await bridge.close();
+  });
+
+  it("returns structured working tree conflicts for git checkout host fetches", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-git-checkout-"));
+    tempDirs.push(tempDirectory);
+    const { repoRoot, branchName } = await createGitCheckoutFixture(tempDirectory, {
+      dirtyWorkingTree: true,
+    });
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-git-checkout-branch-conflict",
+      method: "POST",
+      url: "vscode://codex/git-checkout-branch",
+      body: JSON.stringify({
+        cwd: repoRoot,
+        branch: branchName,
+        hostId: "local",
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-git-checkout-branch-conflict")),
+    );
+
+    expect(getFetchResponse(emittedMessages, "fetch-git-checkout-branch-conflict")).toMatchObject({
+      type: "fetch-response",
+      requestId: "fetch-git-checkout-branch-conflict",
+      responseType: "success",
+      status: 200,
+    });
+    expect(getFetchJsonBody(emittedMessages, "fetch-git-checkout-branch-conflict")).toEqual({
+      status: "error",
+      error: "Your working tree has changes that would be overwritten by checkout.",
+      errorType: "blocked-by-working-tree-changes",
+      conflictedPaths: ["README.md"],
+      execOutput: {
+        command: `git checkout --quiet ${branchName}`,
+        output: expect.stringContaining("README.md"),
+      },
+    });
+    expect(await readCurrentBranch(repoRoot)).toBe("main");
+
+    await bridge.close();
+  });
+});
+
+async function createGitCheckoutFixture(
+  tempDirectory: string,
+  options: {
+    dirtyWorkingTree?: boolean;
+  } = {},
+): Promise<{ repoRoot: string; branchName: string }> {
+  const repoRoot = join(tempDirectory, "repo");
+  const branchName = "feature/test-branch";
+  await runGitCommand(tempDirectory, ["init", "-q", "-b", "main", repoRoot]);
+  await runGitCommand(repoRoot, ["config", "user.name", "Pocodex Test"]);
+  await runGitCommand(repoRoot, ["config", "user.email", "pocodex@example.com"]);
+  await writeFile(join(repoRoot, "README.md"), "main\n", "utf8");
+  await runGitCommand(repoRoot, ["add", "README.md"]);
+  await runGitCommand(repoRoot, ["commit", "-q", "-m", "initial"]);
+  await runGitCommand(repoRoot, ["checkout", "-q", "-b", branchName]);
+  await writeFile(join(repoRoot, "README.md"), "feature branch\n", "utf8");
+  await runGitCommand(repoRoot, ["commit", "-am", "feature change"]);
+  await runGitCommand(repoRoot, ["checkout", "-q", "main"]);
+  if (options.dirtyWorkingTree) {
+    await writeFile(join(repoRoot, "README.md"), "dirty main\n", "utf8");
+  }
+  return { repoRoot, branchName };
+}
+
+async function readCurrentBranch(repoRoot: string): Promise<string> {
+  return runGitCommand(repoRoot, ["branch", "--show-current"]);
+}
+
+async function runGitCommand(cwd: string, args: string[]): Promise<string> {
+  return new Promise((resolveOutput, reject) => {
+    execFile(
+      "git",
+      args,
+      {
+        cwd,
+        encoding: "utf8",
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr.trim() || error.message));
+          return;
+        }
+        resolveOutput(stdout.trim());
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

This restores branch switching from newer Codex UI flows by implementing the missing `vscode://codex/git-checkout-branch` host fetch in Pocodex.

## What changed

- add app-server bridge support for the `git-checkout-branch` Codex host fetch route
- run `git checkout --quiet <branch>` in the requested working directory and return the success/error payload shape the current Codex UI expects
- translate working-tree overwrite failures into structured `blocked-by-working-tree-changes` responses with conflicted paths and exec output
- add regression coverage for both successful branch checkout and dirty-working-tree checkout conflicts

## Root cause

Recent Codex bundles started using a dedicated `vscode://codex/git-checkout-branch` host fetch when the UI switches branches.

- Pocodex did not implement that route, so the request fell through the host fetch router
- the bridge then returned `Unsupported Codex host fetch URL: vscode://codex/git-checkout-branch`
- that broke branch switching from the Codex branch picker even though local git itself was available

## Impact

- branch switching from the Codex UI works again in Pocodex
- dirty working tree conflicts now flow through the newer Codex error path instead of failing as an unsupported host URL
- the new host fetch contract is covered by focused regression tests

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run test/app-server-bridge-git-checkout.test.ts test/app-server-bridge-host-data.test.ts test/app-server-bridge-workers.test.ts`
