### PR TITLE
Fix: restore worktree sidebar threads and delete flows

### DIFF
--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -8,7 +8,7 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 
 import { createInterface } from "node:readline";
 
 import { ensureCodexCliBinary } from "./codex-bundle.js";
-import { deriveCodexHomePath } from "./codex-home.js";
+import { deriveBrowserCodexHomePath, deriveCodexHomePath } from "./codex-home.js";
 import {
   DefaultCodexDesktopGitWorkerBridge,
   type CodexDesktopGitWorkerBridge,
@@ -166,6 +166,12 @@ interface GitRepositoryInfo {
   originUrl: string | null;
 }
 
+interface WorktreeDeleteRequest {
+  worktree: string;
+  reason?: string;
+  force?: boolean;
+  hostConfig: JsonRecord;
+}
 interface GitOriginsResponse {
   origins: GitOriginRecord[];
   homeDir: string;
@@ -291,6 +297,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
   private readonly workspaceRoots = new Set<string>();
   private readonly workspaceRootLabels = new Map<string, string>();
   private readonly codexHomePath: string;
+  private readonly browserCodexHomePath: string;
   private persistedAtomRegistryPath: string;
   private workspaceRootRegistryPath: string;
   private readonly gitWorkerBridge: CodexDesktopGitWorkerBridge;
@@ -301,6 +308,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
   private isClosing = false;
   private isInitialized = false;
   private childExited = false;
+  private readonly pocodexGitWorkerRequests = new Map<string, AbortController>();
   private connectionState: "connecting" | "connected" | "disconnected" = "connecting";
 
   override on(event: "bridge_message", listener: (message: unknown) => void): this;
@@ -318,6 +326,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     this.hostId = options.hostId ?? "local";
     this.cwd = options.cwd;
     this.codexHomePath = options.codexHomePath ?? deriveCodexHomePath();
+    this.browserCodexHomePath = options.codexHomePath ?? deriveBrowserCodexHomePath();
     this.persistedAtomRegistryPath =
       options.persistedAtomRegistryPath ?? derivePersistedAtomRegistryPath();
     this.workspaceRootRegistryPath =
@@ -375,6 +384,8 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     this.connectionState = "disconnected";
     this.fetchRequests.forEach((controller) => controller.abort());
     this.fetchRequests.clear();
+    this.pocodexGitWorkerRequests.forEach((controller) => controller.abort());
+    this.pocodexGitWorkerRequests.clear();
     this.terminalManager.dispose();
     await this.gitWorkerBridge.close().catch((error) => {
       debugLog("git-worker", "failed to close desktop git worker bridge", {
@@ -500,6 +511,12 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
         return;
       case "electron-rename-workspace-root-option":
         await this.handleRenameWorkspaceRootOption(message);
+        return;
+      case "pocodex-git-worker-request":
+        await this.handlePocodexGitWorkerRequest(message);
+        return;
+      case "pocodex-git-worker-cancel":
+        this.handlePocodexGitWorkerCancel(message);
         return;
       case "mcp-request":
         await this.handleMcpRequest(message as unknown as AppServerMcpRequestEnvelope);
@@ -1731,6 +1748,88 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     });
   }
 
+  private async handlePocodexGitWorkerRequest(message: JsonRecord): Promise<void> {
+    const requestId =
+      typeof message.requestId === "string" || typeof message.requestId === "number"
+        ? String(message.requestId)
+        : null;
+    const method = typeof message.method === "string" ? message.method : null;
+    if (
+      !requestId ||
+      !method ||
+      !["codex-worktrees", "resolve-worktree-for-thread", "delete-worktree"].includes(method)
+    ) {
+      return;
+    }
+
+    this.pocodexGitWorkerRequests.get(requestId)?.abort();
+    const controller = new AbortController();
+    this.pocodexGitWorkerRequests.set(requestId, controller);
+
+    try {
+      const value = await this.sendGitWorkerRequest(
+        method,
+        isJsonRecord(message.params) ? message.params : {},
+        controller.signal,
+      );
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      this.emitPocodexGitWorkerResponse({
+        id: requestId,
+        method,
+        result: {
+          type: "ok",
+          value,
+        },
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      this.emitPocodexGitWorkerResponse({
+        id: requestId,
+        method,
+        result: {
+          type: "error",
+          error: {
+            message: normalizeError(error).message,
+          },
+        },
+      });
+    } finally {
+      if (this.pocodexGitWorkerRequests.get(requestId) === controller) {
+        this.pocodexGitWorkerRequests.delete(requestId);
+      }
+    }
+  }
+
+  private handlePocodexGitWorkerCancel(message: JsonRecord): void {
+    const requestId =
+      typeof message.requestId === "string" || typeof message.requestId === "number"
+        ? String(message.requestId)
+        : null;
+    if (!requestId) {
+      return;
+    }
+
+    this.pocodexGitWorkerRequests.get(requestId)?.abort();
+    this.pocodexGitWorkerRequests.delete(requestId);
+  }
+
+  private emitPocodexGitWorkerResponse(response: JsonRecord): void {
+    this.emitBridgeMessage({
+      type: "pocodex-git-worker-response",
+      message: {
+        type: "worker-response",
+        workerId: "git",
+        response,
+      },
+    });
+  }
+
   private async handleCodexFetchRequest(
     rawUrl: string,
     method: string,
@@ -1740,6 +1839,20 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     const url = new URL(rawUrl);
     const path = url.pathname.replace(/^\/+/, "");
     switch (path) {
+      case "worktree-delete":
+        try {
+          return {
+            status: 200,
+            body: await this.handleWorktreeDeleteRequest(body, signal),
+          };
+        } catch (error) {
+          return {
+            status: 500,
+            body: {
+              error: normalizeError(error).message,
+            },
+          };
+        }
       case "apply-patch":
         try {
           return {
@@ -1879,7 +1992,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
         return {
           status: 200,
           body: {
-            codexHome: this.codexHomePath,
+            codexHome: this.browserCodexHomePath,
           },
         };
       case "codex-agents-md":
@@ -2003,6 +2116,10 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
   }
 
+  private async handleWorktreeDeleteRequest(body: unknown, signal: AbortSignal): Promise<unknown> {
+    const request = readWorktreeDeleteRequest(body, this.buildHostConfig());
+    return await this.sendGitWorkerRequest("delete-worktree", request, signal);
+  }
   private async handleRelativeFetchRequest(
     request: RelativeFetchRequestContext,
   ): Promise<RelativeFetchResponse | null> {
@@ -3807,6 +3924,36 @@ async function runGitCommand(cwd: string, args: string[]): Promise<string> {
   });
 }
 
+function readWorktreeDeleteRequest(
+  body: unknown,
+  fallbackHostConfig: JsonRecord,
+): WorktreeDeleteRequest {
+  const params = readCodexFetchParams(body);
+  if (!isJsonRecord(params)) {
+    throw new Error("Worktree delete params are required.");
+  }
+
+  const worktree =
+    typeof params.worktree === "string"
+      ? params.worktree.trim()
+      : typeof params.worktreeGitRoot === "string"
+        ? params.worktreeGitRoot.trim()
+        : "";
+  if (worktree.length === 0) {
+    throw new Error("Worktree path is required.");
+  }
+
+  const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+  const shouldForce = params.force === true || reason.startsWith("settings-delete");
+  const hostConfig = isJsonRecord(params.hostConfig) ? params.hostConfig : fallbackHostConfig;
+
+  return {
+    worktree,
+    reason: reason.length > 0 ? reason : undefined,
+    force: shouldForce || undefined,
+    hostConfig,
+  };
+}
 async function execGhCommand(
   cwd: string,
   args: string[],

--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -143,8 +143,14 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     "reset",
     "submit",
   ]);
+  const POCODEX_LOCAL_GIT_WORKER_METHODS = new Set([
+    "codex-worktrees",
+    "resolve-worktree-for-thread",
+    "delete-worktree",
+  ]);
 
   const workerSubscribers = new Map<string, Set<WorkerMessageListener>>();
+  const pocodexLocalGitWorkerRequestIds = new Set<string>();
   const restorableTerminalAttachments = new Map<string, RestorableTerminalAttachment>();
   const pendingMessages: string[] = [];
   const toastHost = document.createElement("div");
@@ -2519,6 +2525,21 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       return false;
     }
 
+    if (message.type === "pocodex-git-worker-response") {
+      const workerMessage = message.message;
+      const response =
+        isRecord(workerMessage) && isRecord(workerMessage.response) ? workerMessage.response : null;
+      const responseId =
+        response && (typeof response.id === "string" || typeof response.id === "number")
+          ? String(response.id)
+          : null;
+      if (responseId) {
+        pocodexLocalGitWorkerRequestIds.delete(responseId);
+      }
+      dispatchWorkerMessage("git", workerMessage);
+      return true;
+    }
+
     if (message.type === "pocodex-open-workspace-root-picker") {
       const context = message.context === "onboarding" ? "onboarding" : "manual";
       const initialPath = typeof message.initialPath === "string" ? message.initialPath : "";
@@ -3500,6 +3521,75 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     };
   }
 
+  function dispatchWorkerMessage(workerName: string, message: unknown): void {
+    const listeners = workerSubscribers.get(workerName);
+    listeners?.forEach((listener) => listener(message));
+  }
+
+  function shouldHandleGitWorkerMessageLocally(workerName: string, message: unknown): boolean {
+    if (workerName !== "git" || !isRecord(message) || message.type !== "worker-request") {
+      return false;
+    }
+
+    const request = isRecord(message.request) ? message.request : null;
+    return (
+      typeof request?.method === "string" && POCODEX_LOCAL_GIT_WORKER_METHODS.has(request.method)
+    );
+  }
+
+  function maybeSendPocodexLocalGitWorkerRequest(workerName: string, message: unknown): boolean {
+    if (!shouldHandleGitWorkerMessageLocally(workerName, message) || !isRecord(message)) {
+      return false;
+    }
+
+    const request = isRecord(message.request) ? message.request : null;
+    const requestId =
+      request && (typeof request.id === "string" || typeof request.id === "number")
+        ? String(request.id)
+        : null;
+    if (!request || !requestId) {
+      return false;
+    }
+
+    pocodexLocalGitWorkerRequestIds.add(requestId);
+    sendEnvelope({
+      type: "bridge_message",
+      message: {
+        type: "pocodex-git-worker-request",
+        requestId,
+        method: request.method,
+        params: request.params,
+      },
+    });
+    return true;
+  }
+
+  function maybeSendPocodexLocalGitWorkerCancel(workerName: string, message: unknown): boolean {
+    if (
+      workerName !== "git" ||
+      !isRecord(message) ||
+      message.type !== "worker-request-cancel" ||
+      (typeof message.id !== "string" && typeof message.id !== "number")
+    ) {
+      return false;
+    }
+
+    const requestId = String(message.id);
+    if (!pocodexLocalGitWorkerRequestIds.has(requestId)) {
+      return false;
+    }
+
+    pocodexLocalGitWorkerRequestIds.delete(requestId);
+    sendEnvelope({
+      type: "bridge_message",
+      message: {
+        type: "pocodex-git-worker-cancel",
+        requestId,
+      },
+    });
+    return true;
+  }
+
   const electronBridge: ElectronBridge = {
     windowType: "electron",
     sendMessageFromView: async (message) => {
@@ -3519,6 +3609,12 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     },
     getPathForFile: () => null,
     sendWorkerMessageFromView: async (workerName, message) => {
+      if (maybeSendPocodexLocalGitWorkerRequest(workerName, message)) {
+        return;
+      }
+      if (maybeSendPocodexLocalGitWorkerCancel(workerName, message)) {
+        return;
+      }
       sendEnvelope({ type: "worker_message", workerName, message });
     },
     subscribeToWorkerMessages: (workerName, callback) => addWorkerSubscriber(workerName, callback),

--- a/src/lib/codex-desktop-git-worker.ts
+++ b/src/lib/codex-desktop-git-worker.ts
@@ -3,11 +3,12 @@ import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { cp, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve as resolvePath } from "node:path";
 import process from "node:process";
 import { Worker } from "node:worker_threads";
 
 import { ensureCodexDesktopWorkerScript, type CodexDesktopWorkerScript } from "./codex-bundle.js";
+import { listCodexHomePathCandidates } from "./codex-home.js";
 import { debugLog, isDebugEnabled } from "./debug.js";
 
 type GitWorkerMainRpcMethod =
@@ -209,6 +210,17 @@ interface PendingWorkerRequest {
   method: string;
 }
 
+interface CodexWorktreeRecord {
+  dir: string;
+  gitDir: string | null;
+}
+
+interface ResolveWorktreeForThreadResult {
+  worktreeGitRoot: string | null;
+  worktreeWorkspaceRoot: string | null;
+  hasUncommittedChanges: boolean;
+}
+
 interface CodexDesktopGitWorkerBridgeOptions {
   appPath: string;
   resolveWorkerScript?: () => Promise<CodexDesktopWorkerScript>;
@@ -227,6 +239,7 @@ export class DefaultCodexDesktopGitWorkerBridge
   private readonly pendingRequests = new Map<string, PendingWorkerRequest>();
   private readonly commandExecSessions = new Map<string, CommandExecSession>();
   private readonly localApplyPatchControllers = new Map<string, AbortController>();
+  private readonly localWorktreeRequestControllers = new Map<string, AbortController>();
   private worker: Worker | null = null;
   private workerStartPromise: Promise<Worker> | null = null;
   private subscriberCount = 0;
@@ -243,6 +256,7 @@ export class DefaultCodexDesktopGitWorkerBridge
 
   async send(message: unknown): Promise<void> {
     const request = parseGitWorkerRequest(message);
+    let outgoingMessage = message;
     if (request) {
       this.pendingRequests.set(String(request.id), request);
       if (request.method === "apply-patch") {
@@ -258,6 +272,22 @@ export class DefaultCodexDesktopGitWorkerBridge
         }
         return;
       }
+      if (request.method === "codex-worktrees" && shouldHandleWorktreeRequestLocally(message)) {
+        const controller = new AbortController();
+        this.localWorktreeRequestControllers.set(String(request.id), controller);
+        void this.handleLocalCodexWorktreesRequest(request, controller.signal);
+        return;
+      }
+      if (
+        request.method === "resolve-worktree-for-thread" &&
+        shouldHandleWorktreeRequestLocally(message)
+      ) {
+        const controller = new AbortController();
+        this.localWorktreeRequestControllers.set(String(request.id), controller);
+        void this.handleLocalResolveWorktreeForThreadRequest(request, message, controller.signal);
+        return;
+      }
+      outgoingMessage = maybeForceSettingsDeleteWorktreeRequest(message);
     } else {
       const cancellation = parseGitWorkerCancel(message);
       if (cancellation) {
@@ -268,12 +298,20 @@ export class DefaultCodexDesktopGitWorkerBridge
           localApplyPatch.abort();
           return;
         }
+        const localWorktreeRequest = this.localWorktreeRequestControllers.get(
+          String(cancellation.id),
+        );
+        if (localWorktreeRequest) {
+          this.localWorktreeRequestControllers.delete(String(cancellation.id));
+          localWorktreeRequest.abort();
+          return;
+        }
       }
     }
 
     try {
       const worker = await this.ensureWorker();
-      worker.postMessage(message);
+      worker.postMessage(outgoingMessage);
     } catch (error) {
       const normalized = normalizeError(error);
       debugLog("git-worker", "failed to send message", {
@@ -305,6 +343,7 @@ export class DefaultCodexDesktopGitWorkerBridge
     this.isClosing = true;
     this.disposeCommandExecSessions();
     this.disposeLocalApplyPatchRequests();
+    this.disposeLocalWorktreeRequests();
     const worker = this.worker;
     this.worker = null;
     this.workerStartPromise = null;
@@ -708,6 +747,59 @@ export class DefaultCodexDesktopGitWorkerBridge
       controller.abort();
     }
     this.localApplyPatchControllers.clear();
+  }
+
+  private async handleLocalCodexWorktreesRequest(
+    request: PendingWorkerRequest,
+    signal: AbortSignal,
+  ): Promise<void> {
+    try {
+      const value = {
+        worktrees: await listLocalCodexWorktrees(signal),
+      };
+      if (!signal.aborted) {
+        this.emit("message", buildWorkerSuccessResponse(request, value));
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        this.emit("message", buildWorkerErrorResponse(request, normalizeError(error)));
+      }
+    } finally {
+      this.pendingRequests.delete(String(request.id));
+      this.localWorktreeRequestControllers.delete(String(request.id));
+    }
+  }
+
+  private async handleLocalResolveWorktreeForThreadRequest(
+    request: PendingWorkerRequest,
+    message: unknown,
+    signal: AbortSignal,
+  ): Promise<void> {
+    try {
+      const params = parseResolveWorktreeForThreadParams(message);
+      const value = await resolveWorktreeForThreadLocally(
+        params.cwd,
+        params.conversationId,
+        signal,
+      );
+      if (!signal.aborted) {
+        this.emit("message", buildWorkerSuccessResponse(request, value));
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        this.emit("message", buildWorkerErrorResponse(request, normalizeError(error)));
+      }
+    } finally {
+      this.pendingRequests.delete(String(request.id));
+      this.localWorktreeRequestControllers.delete(String(request.id));
+    }
+  }
+
+  private disposeLocalWorktreeRequests(): void {
+    for (const controller of this.localWorktreeRequestControllers.values()) {
+      controller.abort();
+    }
+    this.localWorktreeRequestControllers.clear();
   }
 }
 
@@ -1835,6 +1927,316 @@ function stripOuterQuotes(value: string): string {
     return trimmed.slice(1, -1);
   }
   return trimmed;
+}
+
+function shouldHandleWorktreeRequestLocally(value: unknown): boolean {
+  return isLocalHostConfigValue(readGitWorkerRequestParams(value)?.hostConfig);
+}
+
+function maybeForceSettingsDeleteWorktreeRequest(value: unknown): unknown {
+  const envelope = isJsonRecord(value) ? value : null;
+  const params = readGitWorkerRequestParams(value);
+  if (!envelope || !params || !isLocalHostConfigValue(params.hostConfig)) {
+    return value;
+  }
+
+  const request = isJsonRecord(envelope.request) ? envelope.request : null;
+  if (request?.method !== "delete-worktree") {
+    return value;
+  }
+
+  const reason = typeof params.reason === "string" ? params.reason : "";
+  if (!reason.startsWith("settings-delete") || params.force === true) {
+    return value;
+  }
+
+  return {
+    ...envelope,
+    request: {
+      ...request,
+      params: {
+        ...params,
+        force: true,
+      },
+    },
+  };
+}
+
+function readGitWorkerRequestParams(value: unknown): Record<string, unknown> | null {
+  if (!isJsonRecord(value) || value.type !== "worker-request") {
+    return null;
+  }
+
+  const request = isJsonRecord(value.request) ? value.request : null;
+  if (!request) {
+    return null;
+  }
+
+  return isJsonRecord(request.params) ? request.params : {};
+}
+
+function isLocalHostConfigValue(value: unknown): boolean {
+  return (
+    !isJsonRecord(value) ||
+    value.kind === undefined ||
+    value.kind === "local" ||
+    value.kind === "git"
+  );
+}
+
+function parseResolveWorktreeForThreadParams(value: unknown): {
+  cwd: string;
+  conversationId: string;
+} {
+  const record = assertJsonRecord(
+    readGitWorkerRequestParams(value),
+    "resolve-worktree-for-thread params",
+  );
+  return {
+    cwd: readRequiredString(record.cwd, "cwd"),
+    conversationId: readRequiredString(record.conversationId, "conversationId"),
+  };
+}
+
+async function listLocalCodexWorktrees(signal: AbortSignal): Promise<CodexWorktreeRecord[]> {
+  const seenDirs = new Set<string>();
+  const worktrees: CodexWorktreeRecord[] = [];
+
+  for (const codexHome of listCodexHomePathCandidates()) {
+    for (const worktree of await listLocalCodexWorktreesForHome(codexHome, signal)) {
+      const key = normalizeComparablePath(worktree.dir);
+      if (seenDirs.has(key)) {
+        continue;
+      }
+      seenDirs.add(key);
+      worktrees.push(worktree);
+    }
+  }
+
+  worktrees.sort((left, right) => left.dir.localeCompare(right.dir));
+  return worktrees;
+}
+
+async function listLocalCodexWorktreesForHome(
+  codexHome: string,
+  signal: AbortSignal,
+): Promise<CodexWorktreeRecord[]> {
+  assertNotAborted(signal);
+
+  const worktreesRoot = join(codexHome, "worktrees");
+  let parentEntries;
+  try {
+    parentEntries = await readdir(worktreesRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const worktrees: CodexWorktreeRecord[] = [];
+  for (const parentEntry of parentEntries) {
+    assertNotAborted(signal);
+    if (!parentEntry.isDirectory()) {
+      continue;
+    }
+
+    const parentPath = join(worktreesRoot, parentEntry.name);
+    let worktreeEntries;
+    try {
+      worktreeEntries = await readdir(parentPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const worktreeEntry of worktreeEntries) {
+      assertNotAborted(signal);
+      if (!worktreeEntry.isDirectory()) {
+        continue;
+      }
+
+      const worktreeDir = resolvePath(parentPath, worktreeEntry.name);
+      worktrees.push({
+        dir: worktreeDir,
+        gitDir: await resolveLocalGitDir(worktreeDir, signal),
+      });
+    }
+  }
+
+  return worktrees;
+}
+
+async function resolveWorktreeForThreadLocally(
+  cwd: string,
+  conversationId: string,
+  signal: AbortSignal,
+): Promise<ResolveWorktreeForThreadResult> {
+  const gitRoot = await resolveGitRoot(cwd, process.env, signal);
+  if (!gitRoot) {
+    return {
+      worktreeGitRoot: null,
+      worktreeWorkspaceRoot: null,
+      hasUncommittedChanges: false,
+    };
+  }
+
+  const relativeWorkspacePath = relative(gitRoot, cwd);
+  const worktreeRoots = await listGitWorktreeRoots(gitRoot, signal);
+  const codexWorktreesRootPrefixes = listCodexHomePathCandidates().map((codexHome) =>
+    normalizeComparablePath(join(codexHome, "worktrees")),
+  );
+  const candidates: Array<{
+    worktreeGitRoot: string;
+    worktreeWorkspaceRoot: string;
+    sortTimestamp: number;
+  }> = [];
+
+  for (const worktreeRoot of worktreeRoots) {
+    assertNotAborted(signal);
+    if (!isPathWithinAnyPrefix(worktreeRoot, codexWorktreesRootPrefixes)) {
+      continue;
+    }
+
+    const ownerThreadId = await readLocalWorktreeOwnerThreadId(worktreeRoot, signal);
+    if (ownerThreadId !== conversationId) {
+      continue;
+    }
+
+    const worktreeWorkspaceRoot = isNestedRelativePath(relativeWorkspacePath)
+      ? resolvePath(worktreeRoot, relativeWorkspacePath)
+      : worktreeRoot;
+    candidates.push({
+      worktreeGitRoot: worktreeRoot,
+      worktreeWorkspaceRoot,
+      sortTimestamp: await readSortTimestamp(worktreeRoot),
+    });
+  }
+
+  if (candidates.length === 0) {
+    return {
+      worktreeGitRoot: null,
+      worktreeWorkspaceRoot: null,
+      hasUncommittedChanges: false,
+    };
+  }
+
+  candidates.sort((left, right) => {
+    if (left.sortTimestamp === right.sortTimestamp) {
+      return right.worktreeGitRoot.localeCompare(left.worktreeGitRoot);
+    }
+    return right.sortTimestamp - left.sortTimestamp;
+  });
+
+  const selected = candidates[0]!;
+  const status = await runGitCommand(selected.worktreeWorkspaceRoot, ["status", "--porcelain"], {
+    env: process.env,
+    signal,
+    allowedNonZeroExitCodes: [128],
+  });
+  return {
+    worktreeGitRoot: selected.worktreeGitRoot,
+    worktreeWorkspaceRoot: selected.worktreeWorkspaceRoot,
+    hasUncommittedChanges: status.success && status.stdout.length > 0,
+  };
+}
+
+async function listGitWorktreeRoots(gitRoot: string, signal: AbortSignal): Promise<string[]> {
+  const output = await runGitCommand(gitRoot, ["worktree", "list", "--porcelain"], {
+    env: process.env,
+    signal,
+  });
+  if (!output.success) {
+    throw new Error(output.stderr || output.stdout || "Failed to list git worktrees.");
+  }
+
+  const roots = new Set<string>();
+  for (const line of output.stdout.split(/\r?\n/)) {
+    if (!line.startsWith("worktree ")) {
+      continue;
+    }
+    const worktreeRoot = line.slice("worktree ".length).trim();
+    if (worktreeRoot.length === 0) {
+      continue;
+    }
+    roots.add(resolvePath(worktreeRoot));
+  }
+  return [...roots];
+}
+
+async function readLocalWorktreeOwnerThreadId(
+  worktreeRoot: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const configPath = await resolveLocalGitPath(worktreeRoot, "codex-thread.json", signal);
+  if (!configPath) {
+    return null;
+  }
+
+  try {
+    const rawConfig = await readFile(configPath, "utf8");
+    const parsed = JSON.parse(rawConfig);
+    return typeof parsed?.ownerThreadId === "string" ? parsed.ownerThreadId : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveLocalGitDir(
+  worktreeRoot: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  return resolveLocalGitPath(worktreeRoot, ".git", signal, ["rev-parse", "--git-dir"]);
+}
+
+async function resolveLocalGitPath(
+  worktreeRoot: string,
+  gitPath: string,
+  signal: AbortSignal,
+  command: string[] = ["rev-parse", "--git-path", gitPath],
+): Promise<string | null> {
+  const result = await runGitCommand(worktreeRoot, command, {
+    env: process.env,
+    signal,
+    allowedNonZeroExitCodes: [128],
+  });
+  if (!result.success || result.stdout.length === 0) {
+    return null;
+  }
+
+  return isAbsolute(result.stdout) ? result.stdout : resolvePath(worktreeRoot, result.stdout);
+}
+
+async function readSortTimestamp(path: string): Promise<number> {
+  try {
+    const stats = await stat(path);
+    if (stats.birthtimeMs > 0) {
+      return Math.floor(stats.birthtimeMs);
+    }
+    return Math.floor(stats.mtimeMs);
+  } catch {
+    return 0;
+  }
+}
+
+function isPathWithinAnyPrefix(path: string, prefixes: string[]): boolean {
+  const normalizedPath = normalizeComparablePath(path);
+  return prefixes.some((prefix) => {
+    if (normalizedPath === prefix) {
+      return true;
+    }
+    return normalizedPath.startsWith(`${prefix}/`);
+  });
+}
+
+function isNestedRelativePath(value: string): boolean {
+  return value.length > 0 && !isAbsolute(value) && !/^\.\.(?:[\\/]|$)/.test(value);
+}
+
+function normalizeComparablePath(value: string): string {
+  return resolvePath(value).replaceAll("\\", "/").replace(/\/+$/, "").toLowerCase();
+}
+
+function assertNotAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new Error("Operation canceled");
+  }
 }
 
 function parseWorktreeCleanupInputs(value: unknown): WorktreeCleanupInputs {

--- a/src/lib/codex-home.ts
+++ b/src/lib/codex-home.ts
@@ -7,6 +7,22 @@ export function deriveCodexHomePath(): string {
   return listCodexHomePathCandidates()[0] ?? join(homedir(), ".codex");
 }
 
+export function deriveBrowserCodexHomePath(): string {
+  const configuredCodexHome = normalizeEnvironmentPath(process.env.CODEX_HOME);
+  if (configuredCodexHome) {
+    return configuredCodexHome;
+  }
+
+  if (!isRunningInWsl()) {
+    return join(homedir(), ".codex");
+  }
+
+  // The desktop bundle assumes a single Codex home when filtering local threads.
+  // In WSL we may surface sessions from both the Windows and Linux homes, so report
+  // their shared ancestor to keep both sets visible in browser-side path checks.
+  return deriveSharedAncestorPath(listCodexHomePathCandidates()) ?? deriveCodexHomePath();
+}
+
 export function listCodexHomePathCandidates(): string[] {
   const candidates: string[] = [];
   addPathCandidate(candidates, normalizeEnvironmentPath(process.env.CODEX_HOME));
@@ -85,6 +101,64 @@ function addPathCandidate(candidates: string[], candidate: string | null): void 
   }
 
   candidates.push(candidate);
+}
+
+function deriveSharedAncestorPath(paths: string[]): string | null {
+  const normalizedPaths = paths
+    .map((path) => normalizeSharedAncestorPath(path))
+    .filter((path): path is string => path.length > 0);
+  const [firstPath, ...remainingPaths] = normalizedPaths;
+  if (!firstPath) {
+    return null;
+  }
+
+  let sharedPath: string | null = firstPath;
+  for (const path of remainingPaths) {
+    sharedPath = deriveCommonAncestorPath(sharedPath, path);
+    if (!sharedPath) {
+      return null;
+    }
+  }
+
+  return sharedPath;
+}
+
+function normalizeSharedAncestorPath(path: string): string {
+  const normalizedPath = path.replaceAll("\\", "/");
+  if (normalizedPath.length <= 1) {
+    return normalizedPath;
+  }
+
+  return normalizedPath.replace(/\/+$/, "");
+}
+
+function deriveCommonAncestorPath(leftPath: string, rightPath: string): string | null {
+  const leftIsAbsolute = leftPath.startsWith("/");
+  if (leftIsAbsolute !== rightPath.startsWith("/")) {
+    return null;
+  }
+
+  const leftSegments = leftPath.split("/").filter((segment) => segment.length > 0);
+  const rightSegments = rightPath.split("/").filter((segment) => segment.length > 0);
+  const sharedSegmentCount = Math.min(leftSegments.length, rightSegments.length);
+  let segmentIndex = 0;
+  while (
+    segmentIndex < sharedSegmentCount &&
+    leftSegments[segmentIndex] === rightSegments[segmentIndex]
+  ) {
+    segmentIndex += 1;
+  }
+
+  if (leftIsAbsolute) {
+    return segmentIndex === 0 ? "/" : `/${leftSegments.slice(0, segmentIndex).join("/")}`;
+  }
+
+  if (segmentIndex === 0) {
+    return null;
+  }
+
+  const sharedRelativePath = leftSegments.slice(0, segmentIndex).join("/");
+  return /^[A-Za-z]:$/u.test(sharedRelativePath) ? `${sharedRelativePath}/` : sharedRelativePath;
 }
 
 function resolveWslWindowsUserProfile(): string | null {

--- a/src/lib/request-id.ts
+++ b/src/lib/request-id.ts
@@ -112,6 +112,32 @@ export function routeHostMessage(message: unknown): HostMessageRouteResult {
     };
   }
 
+  if (
+    message.type === "pocodex-git-worker-response" &&
+    isJsonRecord(message.message) &&
+    isJsonRecord(message.message.response) &&
+    typeof message.message.response.id === "string"
+  ) {
+    const parsed = stripPrefixedRequestId(message.message.response.id);
+    if (!parsed) {
+      return { deliver: false };
+    }
+    return {
+      deliver: true,
+      sessionId: parsed.sessionId,
+      message: {
+        ...message,
+        message: {
+          ...message.message,
+          response: {
+            ...message.message.response,
+            id: parsed.requestId,
+          },
+        },
+      },
+    };
+  }
+
   return {
     deliver: true,
     message,

--- a/test/app-server-bridge-host-data.test.ts
+++ b/test/app-server-bridge-host-data.test.ts
@@ -131,6 +131,33 @@ describeAppServerBridge(({ children }) => {
     await bridge.close();
   });
 
+  it("reports a shared browser codex home inside WSL", async () => {
+    delete process.env.CODEX_HOME;
+    process.env.USERPROFILE = "/mnt/c/Users/tester";
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-home",
+      method: "POST",
+      url: "vscode://codex/codex-home",
+    });
+
+    await waitForCondition(() => Boolean(getFetchResponse(emittedMessages, "fetch-home")));
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-home")).toEqual({
+      codexHome: "/",
+    });
+
+    await bridge.close();
+  });
+
   it("generates thread titles for host fetch requests", async () => {
     const bridge = await createBridge(children);
     const emittedMessages: unknown[] = [];

--- a/test/app-server-bridge-worktree-delete.test.ts
+++ b/test/app-server-bridge-worktree-delete.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from "node:events";
+
+import { expect, it } from "vitest";
+
+import {
+  createBridge,
+  describeAppServerBridge,
+  getFetchResponse,
+} from "./support/app-server-bridge-test-kit.js";
+
+class TestGitWorkerBridge extends EventEmitter {
+  readonly sentMessages: unknown[] = [];
+
+  async send(message: unknown): Promise<void> {
+    this.sentMessages.push(message);
+
+    if (
+      typeof message !== "object" ||
+      message === null ||
+      !("type" in message) ||
+      (message as { type?: unknown }).type !== "worker-request"
+    ) {
+      return;
+    }
+
+    const request =
+      "request" in message && typeof message.request === "object" && message.request !== null
+        ? (message.request as {
+            id?: unknown;
+            method?: unknown;
+          })
+        : null;
+    if (!request || typeof request.id !== "string" || typeof request.method !== "string") {
+      return;
+    }
+
+    queueMicrotask(() => {
+      this.emit("message", {
+        type: "worker-response",
+        workerId: "git",
+        response: {
+          id: request.id,
+          method: request.method,
+          result: {
+            type: "ok",
+            value: {
+              status: "success",
+            },
+          },
+        },
+      });
+    });
+  }
+
+  async subscribe(): Promise<void> {}
+
+  async unsubscribe(): Promise<void> {}
+
+  async close(): Promise<void> {}
+}
+
+describeAppServerBridge(({ children }) => {
+  it("forwards settings-targeted worktree deletes to the git worker with force enabled", async () => {
+    const gitWorkerBridge = new TestGitWorkerBridge();
+    const bridge = await createBridge(children, {
+      gitWorkerBridge: gitWorkerBridge as never,
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-worktree-delete",
+      method: "POST",
+      url: "vscode://codex/worktree-delete",
+      body: JSON.stringify({
+        hostId: "local",
+        worktree: "/tmp/pocodex-worktree",
+        reason: "settings-delete-targeted",
+      }),
+    });
+
+    await waitForFetchResponse(emittedMessages, "fetch-worktree-delete");
+
+    expect(getFetchResponse(emittedMessages, "fetch-worktree-delete")).toMatchObject({
+      type: "fetch-response",
+      requestId: "fetch-worktree-delete",
+      responseType: "success",
+      status: 200,
+    });
+    expect(gitWorkerBridge.sentMessages).toEqual([
+      {
+        type: "worker-request",
+        workerId: "git",
+        request: {
+          id: expect.any(String),
+          method: "delete-worktree",
+          params: {
+            worktree: "/tmp/pocodex-worktree",
+            reason: "settings-delete-targeted",
+            force: true,
+            hostConfig: {
+              id: "local",
+              display_name: "Local",
+              kind: "local",
+            },
+          },
+        },
+      },
+    ]);
+
+    await bridge.close();
+  });
+});
+
+async function waitForFetchResponse(messages: unknown[], requestId: string): Promise<void> {
+  const startedAt = Date.now();
+  while (!getFetchResponse(messages, requestId)) {
+    if (Date.now() - startedAt > 2_000) {
+      throw new Error(`Timed out waiting for fetch response ${requestId}.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}

--- a/test/codex-desktop-git-worker.test.ts
+++ b/test/codex-desktop-git-worker.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import process from "node:process";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -39,9 +39,18 @@ class FakeWorker extends EventEmitter {
   }
 }
 
+const originalCodexHome = process.env.CODEX_HOME;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalWslDistroName = process.env.WSL_DISTRO_NAME;
+
 describe("DefaultCodexDesktopGitWorkerBridge", () => {
   afterEach(() => {
     FakeWorker.instances = [];
+    restoreEnv("CODEX_HOME", originalCodexHome);
+    restoreEnv("HOME", originalHome);
+    restoreEnv("USERPROFILE", originalUserProfile);
+    restoreEnv("WSL_DISTRO_NAME", originalWslDistroName);
   });
 
   it("spawns the desktop worker lazily and forwards git messages", async () => {
@@ -595,6 +604,222 @@ describe("DefaultCodexDesktopGitWorkerBridge", () => {
       await rm(tempDirectory, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("handles codex-worktrees locally across Codex home candidates and directory names", async () => {
+    const bridge = new DefaultCodexDesktopGitWorkerBridge({
+      appPath: "/Applications/Codex.app",
+      resolveWorkerScript: async () => ({
+        workerPath: "/tmp/pocodex-worker.js",
+        metadata: {
+          appPath: "/Applications/Codex.app",
+          buildFlavor: "stable",
+          buildNumber: "123",
+          version: "1.2.3",
+        },
+      }),
+      WorkerClass: FakeWorker as never,
+    });
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-codex-worktrees-"));
+    const repoRoot = join(tempDirectory, "repo");
+    const primaryCodexHome = join(tempDirectory, "primary-codex-home");
+    const secondaryUserProfile = join(tempDirectory, "windows-user");
+    const secondaryCodexHome = join(secondaryUserProfile, ".codex");
+    const homeDirectory = join(tempDirectory, "home");
+    const primaryWorktree = join(primaryCodexHome, "worktrees", "abcd", "pocodex");
+    const secondaryWorktree = join(secondaryCodexHome, "worktrees", "zz9569", "pocodex");
+
+    process.env.CODEX_HOME = primaryCodexHome;
+    process.env.HOME = homeDirectory;
+    process.env.USERPROFILE = secondaryUserProfile;
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    try {
+      await initializeGitRepository(repoRoot);
+      await createDetachedWorktree(repoRoot, primaryWorktree);
+      await createDetachedWorktree(repoRoot, secondaryWorktree);
+
+      const responsePromise = waitForBridgeWorkerResponse(bridge, "codex-worktrees-1");
+      await bridge.send({
+        type: "worker-request",
+        workerId: "git",
+        request: {
+          id: "codex-worktrees-1",
+          method: "codex-worktrees",
+          params: {
+            hostConfig: {
+              id: "local",
+              display_name: "Local",
+              kind: "git",
+            },
+          },
+        },
+      });
+
+      expect(await responsePromise).toMatchObject({
+        type: "worker-response",
+        workerId: "git",
+        response: {
+          id: "codex-worktrees-1",
+          method: "codex-worktrees",
+          result: {
+            type: "ok",
+            value: {
+              worktrees: expect.arrayContaining([
+                expect.objectContaining({
+                  dir: primaryWorktree,
+                  gitDir: expect.any(String),
+                }),
+                expect.objectContaining({
+                  dir: secondaryWorktree,
+                  gitDir: expect.any(String),
+                }),
+              ]),
+            },
+          },
+        },
+      });
+      expect(FakeWorker.instances).toHaveLength(0);
+    } finally {
+      await bridge.close();
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("resolves thread worktrees locally across Codex home candidates", async () => {
+    const bridge = new DefaultCodexDesktopGitWorkerBridge({
+      appPath: "/Applications/Codex.app",
+      resolveWorkerScript: async () => ({
+        workerPath: "/tmp/pocodex-worker.js",
+        metadata: {
+          appPath: "/Applications/Codex.app",
+          buildFlavor: "stable",
+          buildNumber: "123",
+          version: "1.2.3",
+        },
+      }),
+      WorkerClass: FakeWorker as never,
+    });
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-resolve-thread-worktree-"));
+    const repoRoot = join(tempDirectory, "repo");
+    const primaryCodexHome = join(tempDirectory, "primary-codex-home");
+    const secondaryUserProfile = join(tempDirectory, "windows-user");
+    const secondaryCodexHome = join(secondaryUserProfile, ".codex");
+    const homeDirectory = join(tempDirectory, "home");
+    const primaryWorktree = join(primaryCodexHome, "worktrees", "abcd", "pocodex");
+    const secondaryWorktree = join(secondaryCodexHome, "worktrees", "beef", "pocodex");
+
+    process.env.CODEX_HOME = primaryCodexHome;
+    process.env.HOME = homeDirectory;
+    process.env.USERPROFILE = secondaryUserProfile;
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    try {
+      await initializeGitRepository(repoRoot);
+      await createDetachedWorktree(repoRoot, primaryWorktree);
+      await createDetachedWorktree(repoRoot, secondaryWorktree);
+      await writeThreadOwnerConfig(secondaryWorktree, "conv_123");
+
+      const responsePromise = waitForBridgeWorkerResponse(bridge, "resolve-worktree-1");
+      await bridge.send({
+        type: "worker-request",
+        workerId: "git",
+        request: {
+          id: "resolve-worktree-1",
+          method: "resolve-worktree-for-thread",
+          params: {
+            cwd: repoRoot,
+            conversationId: "conv_123",
+            hostConfig: {
+              id: "local",
+              display_name: "Local",
+              kind: "git",
+            },
+          },
+        },
+      });
+
+      expect(await responsePromise).toMatchObject({
+        type: "worker-response",
+        workerId: "git",
+        response: {
+          id: "resolve-worktree-1",
+          method: "resolve-worktree-for-thread",
+          result: {
+            type: "ok",
+            value: {
+              worktreeGitRoot: secondaryWorktree,
+              worktreeWorkspaceRoot: secondaryWorktree,
+              hasUncommittedChanges: false,
+            },
+          },
+        },
+      });
+      expect(FakeWorker.instances).toHaveLength(0);
+    } finally {
+      await bridge.close();
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  it("forces settings-triggered worktree deletes before forwarding them", async () => {
+    const bridge = new DefaultCodexDesktopGitWorkerBridge({
+      appPath: "/Applications/Codex.app",
+      resolveWorkerScript: async () => ({
+        workerPath: "/tmp/pocodex-worker.js",
+        metadata: {
+          appPath: "/Applications/Codex.app",
+          buildFlavor: "stable",
+          buildNumber: "123",
+          version: "1.2.3",
+        },
+      }),
+      WorkerClass: FakeWorker as never,
+    });
+
+    try {
+      await bridge.send({
+        type: "worker-request",
+        workerId: "git",
+        request: {
+          id: "delete-worktree-1",
+          method: "delete-worktree",
+          params: {
+            worktree: "/tmp/pocodex-worktree",
+            reason: "settings-delete-targeted",
+            hostConfig: {
+              id: "local",
+              display_name: "Local",
+              kind: "git",
+            },
+          },
+        },
+      });
+
+      expect(FakeWorker.instances).toHaveLength(1);
+      expect(FakeWorker.instances[0]?.postedMessages).toEqual([
+        {
+          type: "worker-request",
+          workerId: "git",
+          request: {
+            id: "delete-worktree-1",
+            method: "delete-worktree",
+            params: {
+              worktree: "/tmp/pocodex-worktree",
+              reason: "settings-delete-targeted",
+              force: true,
+              hostConfig: {
+                id: "local",
+                display_name: "Local",
+                kind: "git",
+              },
+            },
+          },
+        },
+      ]);
+    } finally {
+      await bridge.close();
+    }
+  });
 
   it("reports applied paths for hunk-only unstaged revert requests", async () => {
     const bridge = new DefaultCodexDesktopGitWorkerBridge({
@@ -1615,6 +1840,35 @@ async function waitForPostedMessage(
   throw new Error(`Timed out waiting for posted message ${requestId}`);
 }
 
+async function initializeGitRepository(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, "README.md"), "# Pocodex\n", "utf8");
+  execFileSync("git", ["init", "-q"], { cwd: directory });
+  execFileSync("git", ["config", "user.name", "Pocodex Test"], { cwd: directory });
+  execFileSync("git", ["config", "user.email", "pocodex@example.com"], { cwd: directory });
+  execFileSync("git", ["add", "README.md"], { cwd: directory });
+  execFileSync("git", ["commit", "--quiet", "-m", "init"], { cwd: directory });
+}
+
+async function createDetachedWorktree(repoRoot: string, worktreeRoot: string): Promise<void> {
+  await mkdir(dirname(worktreeRoot), { recursive: true });
+  execFileSync("git", ["worktree", "add", "--detach", worktreeRoot, "HEAD"], { cwd: repoRoot });
+}
+
+async function writeThreadOwnerConfig(worktreeRoot: string, conversationId: string): Promise<void> {
+  const gitPath = execFileSync("git", ["rev-parse", "--git-path", "codex-thread.json"], {
+    cwd: worktreeRoot,
+    encoding: "utf8",
+  }).trim();
+  const configPath = gitPath.startsWith("/") ? gitPath : join(worktreeRoot, gitPath);
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    `${JSON.stringify({ version: 1, ownerThreadId: conversationId }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
 async function createGitOnlyPath(tempDirectory: string): Promise<string> {
   const gitBinary = execFileSync("which", ["git"], {
     encoding: "utf8",
@@ -1713,4 +1967,13 @@ function decodeDeltaChunk(value: {
   };
 }): string {
   return Buffer.from(value.params.delta.chunk).toString("utf8");
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
 }

--- a/test/codex-home.test.ts
+++ b/test/codex-home.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { execFileSync } from "node:child_process";
 
-import { deriveCodexHomePath } from "../src/lib/codex-home.js";
+import { deriveBrowserCodexHomePath, deriveCodexHomePath } from "../src/lib/codex-home.js";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
@@ -60,6 +60,45 @@ describe("deriveCodexHomePath", () => {
     });
 
     expect(deriveCodexHomePath()).toBe("/mnt/c/Users/tester/.codex");
+  });
+});
+
+describe("deriveBrowserCodexHomePath", () => {
+  const originalCodexHome = process.env.CODEX_HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalWslDistroName = process.env.WSL_DISTRO_NAME;
+  const originalWslInterop = process.env.WSL_INTEROP;
+
+  afterEach(() => {
+    restoreEnv("CODEX_HOME", originalCodexHome);
+    restoreEnv("USERPROFILE", originalUserProfile);
+    restoreEnv("WSL_DISTRO_NAME", originalWslDistroName);
+    restoreEnv("WSL_INTEROP", originalWslInterop);
+  });
+
+  it("returns a shared browser codex home inside WSL", () => {
+    delete process.env.CODEX_HOME;
+    process.env.USERPROFILE = "/mnt/c/Users/tester";
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    expect(deriveBrowserCodexHomePath()).toBe("/");
+  });
+
+  it("preserves the configured codex home inside WSL", () => {
+    process.env.CODEX_HOME = "/tmp/custom-codex-home";
+    process.env.USERPROFILE = "/mnt/c/Users/tester";
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    expect(deriveBrowserCodexHomePath()).toBe("/tmp/custom-codex-home");
+  });
+
+  it("preserves the configured codex home outside WSL", () => {
+    process.env.CODEX_HOME = "/tmp/custom-codex-home";
+    delete process.env.USERPROFILE;
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSL_INTEROP;
+
+    expect(deriveBrowserCodexHomePath()).toBe("/tmp/custom-codex-home");
   });
 });
 

--- a/test/request-id.test.ts
+++ b/test/request-id.test.ts
@@ -75,4 +75,46 @@ describe("request-id routing", () => {
       },
     });
   });
+
+  it("routes Pocodex git worker responses by nested worker response id", () => {
+    const routed = routeHostMessage({
+      type: "pocodex-git-worker-response",
+      message: {
+        type: "worker-response",
+        workerId: "git",
+        response: {
+          id: "pocodex:session-a:git-1",
+          method: "codex-worktrees",
+          result: {
+            type: "ok",
+            value: {
+              worktrees: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(routed).toEqual({
+      deliver: true,
+      sessionId: "session-a",
+      message: {
+        type: "pocodex-git-worker-response",
+        message: {
+          type: "worker-response",
+          workerId: "git",
+          response: {
+            id: "git-1",
+            method: "codex-worktrees",
+            result: {
+              type: "ok",
+              value: {
+                worktrees: [],
+              },
+            },
+          },
+        },
+      },
+    });
+  });
 });

--- a/test/support/app-server-bridge-test-kit.ts
+++ b/test/support/app-server-bridge-test-kit.ts
@@ -26,6 +26,7 @@ export const tempDirs: string[] = [];
 export const mockPtys: MockPty[] = [];
 const originalCodexHome = process.env.CODEX_HOME;
 const originalShell = process.env.SHELL;
+const originalUserProfile = process.env.USERPROFILE;
 const originalWslDistroName = process.env.WSL_DISTRO_NAME;
 const originalWslInterop = process.env.WSL_INTEROP;
 export const TEST_WORKSPACE_ROOT = process.cwd();
@@ -238,6 +239,11 @@ export function describeAppServerBridge(
         delete process.env.WSL_INTEROP;
       } else {
         process.env.WSL_INTEROP = originalWslInterop;
+      }
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
       }
       process.env.SHELL = originalShell;
       vi.clearAllMocks();


### PR DESCRIPTION
## Summary

This restores missing local worktree threads in the sidebar and fixes settings-triggered worktree deletion so Pocodex once again shows and manages Codex worktrees the way the current desktop bundle expects.

## What changed

- route local `codex-worktrees`, `resolve-worktree-for-thread`, and `delete-worktree` requests through Pocodex instead of relying on unsupported direct bundle worker paths
- add `vscode://codex/worktree-delete` handling in the app-server bridge and normalize settings-targeted deletes before forwarding them to the git worker
- discover worktrees across local Codex-home candidates and resolve thread-owned worktrees locally in the desktop git worker, including non-hex worktree directory names
- report a browser-facing Codex-home path that keeps WSL worktree threads visible to the current sidebar relevance filter
- add regression coverage for host data, request-id routing, worktree deletion, Codex-home selection, and local git-worker worktree resolution

## Root cause

- the current Codex bundle filters sidebar visibility for local threads against a single `codexHome` path, which caused valid `/root/.codex/worktrees/...` threads to disappear when Pocodex surfaced a Windows-side Codex home in WSL
- the settings UI deletes worktrees through `vscode://codex/worktree-delete`, but Pocodex did not implement that host fetch route
- the bundle also expected local worktree worker methods to round-trip through the browser/host bridge, while Pocodex only supported the older direct paths

## Impact

- missing worktree conversations show up in the Threads sidebar again
- settings-based worktree deletion succeeds instead of failing with `Failed to delete worktree`
- local worktree listing and per-thread worktree resolution are covered by focused regressions, including mixed Codex-home WSL setups

## Validation

- `pnpm run check:commit`
- `pnpm vitest run test/app-server-bridge-worktree-delete.test.ts test/codex-home.test.ts test/app-server-bridge-host-data.test.ts test/codex-desktop-git-worker.test.ts test/request-id.test.ts --maxWorkers=1`
- live local verification on fresh Pocodex dev servers confirmed `/settings/worktrees` showed the previously missing worktrees, settings delete removed a worktree without the failure toast, and `http://127.0.0.1:8806/local/019d9486-c2e6-7eb2-9f38-892730afdb09` showed the missing summary worktree thread in the left sidebar
