### PR TITLE
Fix: restore the Summary tab in Pocodex

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,11 @@ import { basename, dirname } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { AppServerBridge } from "./lib/app-server-bridge.js";
+import {
+  AppServerBridge,
+  buildLocalHostConfig,
+  resolveLocalHostKind,
+} from "./lib/app-server-bridge.js";
 import { normalizeCliArgv } from "./lib/cli-args.js";
 import { loadCodexBundle, resolveDefaultCodexAppPath } from "./lib/codex-bundle.js";
 import { renderBootstrapScript } from "./lib/bootstrap-script.js";
@@ -64,9 +68,16 @@ async function main(): Promise<void> {
     buildFlavor: bundle.buildFlavor,
     buildNumber: bundle.buildNumber,
   }).catch(() => null);
+  const hostKind = await resolveLocalHostKind(process.cwd());
   const relay = await AppServerBridge.connect({
     appPath: options.appPath,
     cwd: process.cwd(),
+    extensionInfo: {
+      version: bundle.version,
+      buildFlavor: bundle.buildFlavor,
+      buildNumber: bundle.buildNumber,
+    },
+    hostKind,
   });
 
   const sentryOptions: SentryInitOptions = {
@@ -97,6 +108,7 @@ async function main(): Promise<void> {
       return patchIndexHtml(indexHtml, {
         bootstrapScript: renderBootstrapScript({
           devMode: options.devMode,
+          hostConfig: buildLocalHostConfig("local", hostKind),
           sentryOptions,
           stylesheetHref: POCODEX_STYLESHEET_HREF,
           importIconSvg: await readFile(importIconSvgPath, "utf8"),

--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -45,12 +45,28 @@ import {
 interface AppServerBridgeOptions {
   appPath: string;
   cwd: string;
+  extensionInfo?: AppExtensionInfo;
   hostId?: string;
+  hostKind?: LocalHostKind;
   codexHomePath?: string;
   persistedAtomRegistryPath?: string;
   workspaceRootRegistryPath?: string;
   gitWorkerBridge?: CodexDesktopGitWorkerBridge;
   codexCliPath?: string;
+}
+
+export type LocalHostKind = "git" | "local";
+
+export interface LocalHostConfig {
+  id: string;
+  display_name: string;
+  kind: LocalHostKind;
+}
+
+interface AppExtensionInfo {
+  version: string;
+  buildFlavor: string;
+  buildNumber: string;
 }
 
 interface WhamUsageCredits {
@@ -270,8 +286,10 @@ const LOCAL_UNSUPPORTED_FETCH_BODY = {
 };
 
 export class AppServerBridge extends EventEmitter implements HostBridge {
+  private readonly extensionInfo: AppExtensionInfo;
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly hostId: string;
+  private readonly hostKind: LocalHostKind;
   private readonly cwd: string;
   private readonly terminalManager: TerminalSessionManager;
   private readonly localRequests = new Map<
@@ -315,7 +333,13 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
 
   private constructor(options: AppServerBridgeOptions) {
     super();
+    this.extensionInfo = options.extensionInfo ?? {
+      version: "0.1.0",
+      buildFlavor: "pocodex",
+      buildNumber: "0",
+    };
     this.hostId = options.hostId ?? "local";
+    this.hostKind = options.hostKind ?? "local";
     this.cwd = options.cwd;
     this.codexHomePath = options.codexHomePath ?? deriveCodexHomePath();
     this.persistedAtomRegistryPath =
@@ -821,7 +845,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       clientInfo: {
         name: "pocodex",
         title: "Pocodex",
-        version: "0.1.0",
+        version: this.extensionInfo.version,
       },
       capabilities: {
         experimentalApi: true,
@@ -1811,11 +1835,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       case "extension-info":
         return {
           status: 200,
-          body: {
-            version: "0.1.0",
-            buildFlavor: "pocodex",
-            buildNumber: "0",
-          },
+          body: this.extensionInfo,
         };
       case "is-copilot-api-available":
         return {
@@ -2990,12 +3010,8 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     });
   }
 
-  private buildHostConfig(): Record<string, string> {
-    return {
-      id: this.hostId,
-      display_name: "Local",
-      kind: "local",
-    };
+  private buildHostConfig(): LocalHostConfig {
+    return buildLocalHostConfig(this.hostId, this.hostKind);
   }
 
   private emitFetchSuccess(
@@ -3586,6 +3602,22 @@ async function resolveGitOrigins(
     origins: Array.from(originsByDir.values()),
     homeDir: homedir(),
   };
+}
+
+export function buildLocalHostConfig(
+  hostId = "local",
+  hostKind: LocalHostKind = "local",
+): LocalHostConfig {
+  return {
+    id: hostId,
+    display_name: "Local",
+    kind: hostKind,
+  };
+}
+
+export async function resolveLocalHostKind(cwd: string): Promise<LocalHostKind> {
+  const repository = await resolveGitRepository(cwd, new Map<string, GitRepositoryInfo>());
+  return repository ? "git" : "local";
 }
 
 async function resolveGitOrigin(

--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -7,6 +7,11 @@ import { serializeInlineScript } from "./inline-script.js";
 
 export interface BootstrapScriptConfig {
   devMode?: boolean;
+  hostConfig?: {
+    id: string;
+    display_name: string;
+    kind: "git" | "local";
+  };
   sentryOptions: SentryInitOptions;
   stylesheetHref: string;
   importIconSvg?: string;
@@ -99,6 +104,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     windowType: "electron";
     sendMessageFromView(message: unknown): Promise<void>;
     getPathForFile(): null;
+    getSharedObjectSnapshotValue?(key: string): unknown;
     sendWorkerMessageFromView(workerName: string, message: unknown): Promise<void>;
     subscribeToWorkerMessages(workerName: string, callback: WorkerMessageListener): () => void;
     showContextMenu(): Promise<void>;
@@ -146,6 +152,17 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
   const workerSubscribers = new Map<string, Set<WorkerMessageListener>>();
   const restorableTerminalAttachments = new Map<string, RestorableTerminalAttachment>();
+  const sharedObjectSnapshots = new Map<string, unknown>([
+    [
+      "host_config",
+      config.hostConfig ?? {
+        id: LOCAL_HOST_ID,
+        display_name: "Local",
+        kind: "local",
+      },
+    ],
+    ["remote_connections", []],
+  ]);
   const pendingMessages: string[] = [];
   const toastHost = document.createElement("div");
   const statusHost = document.createElement("div");
@@ -2323,9 +2340,20 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     const overriddenMessage = overrideEnterBehaviorInMessage(message);
     rememberDispatchedEnterBehavior(overriddenMessage);
     syncSidebarModeWithBridgeMessage(overriddenMessage);
+    if (isRecord(overriddenMessage)) {
+      rememberSharedObjectSnapshot(overriddenMessage);
+    }
     syncThreadQueryWithBridgeMessage(overriddenMessage);
     syncRestorableTerminalAttachments(overriddenMessage, "incoming");
     return overriddenMessage;
+  }
+
+  function rememberSharedObjectSnapshot(message: Record<string, unknown>): void {
+    if (message.type !== "shared-object-updated" || typeof message.key !== "string") {
+      return;
+    }
+
+    sharedObjectSnapshots.set(message.key, message.value ?? null);
   }
 
   function overrideEnterBehaviorInMessage(message: Record<string, unknown>): unknown {
@@ -3518,6 +3546,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       }
     },
     getPathForFile: () => null,
+    getSharedObjectSnapshotValue: (key) => sharedObjectSnapshots.get(key) ?? null,
     sendWorkerMessageFromView: async (workerName, message) => {
       sendEnvelope({ type: "worker_message", workerName, message });
     },

--- a/src/lib/codex-desktop-git-worker.ts
+++ b/src/lib/codex-desktop-git-worker.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { cp, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { platform, tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 import { Worker } from "node:worker_threads";
@@ -11,6 +11,7 @@ import { ensureCodexDesktopWorkerScript, type CodexDesktopWorkerScript } from ".
 import { debugLog, isDebugEnabled } from "./debug.js";
 
 type GitWorkerMainRpcMethod =
+  | "platform-family"
   | "worktree-cleanup-inputs"
   | "fs-read-file"
   | "fs-write-file"
@@ -408,6 +409,10 @@ export class DefaultCodexDesktopGitWorkerBridge
 
     try {
       switch (message.method as GitWorkerMainRpcMethod) {
+        case "platform-family": {
+          postMainRpcSuccess(worker, message, platform() === "win32" ? "windows" : "unix");
+          return;
+        }
         case "worktree-cleanup-inputs": {
           const params = parseWorktreeCleanupInputs(message.params);
           postMainRpcSuccess(worker, message, {

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -5,7 +5,11 @@ import { basename, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { EventEmitter } from "node:events";
 
-import { AppServerBridge } from "./app-server-bridge.js";
+import {
+  AppServerBridge,
+  buildLocalHostConfig,
+  resolveLocalHostKind,
+} from "./app-server-bridge.js";
 import { renderBootstrapScript } from "./bootstrap-script.js";
 import { loadCodexBundle } from "./codex-bundle.js";
 import { patchIndexHtml } from "./html-patcher.js";
@@ -152,10 +156,17 @@ class ManagedPocodexRuntime extends EventEmitter implements PocodexRuntime {
       const bundle = await loadCodexBundle(this.options.appPath);
       const pocodexCssPath = fileURLToPath(new URL("../pocodex.css", import.meta.url));
       const importIconSvgPath = fileURLToPath(new URL("../images/import.svg", import.meta.url));
+      const hostKind = await resolveLocalHostKind(this.options.cwd);
 
       relay = await AppServerBridge.connect({
         appPath: this.options.appPath,
         cwd: this.options.cwd,
+        extensionInfo: {
+          version: bundle.version,
+          buildFlavor: bundle.buildFlavor,
+          buildNumber: bundle.buildNumber,
+        },
+        hostKind,
       });
 
       relayErrorListener = (error) => {
@@ -191,6 +202,7 @@ class ManagedPocodexRuntime extends EventEmitter implements PocodexRuntime {
           return patchIndexHtml(indexHtml, {
             bootstrapScript: renderBootstrapScript({
               devMode: this.options.devMode,
+              hostConfig: buildLocalHostConfig("local", hostKind),
               sentryOptions,
               stylesheetHref: POCODEX_STYLESHEET_HREF,
               importIconSvg: await readFile(importIconSvgPath, "utf8"),

--- a/test/app-server-bridge-basic.test.ts
+++ b/test/app-server-bridge-basic.test.ts
@@ -89,6 +89,46 @@ describeAppServerBridge(({ children }) => {
     await bridge.close();
   });
 
+  it("uses the configured Codex bundle metadata for extension info", async () => {
+    const bridge = await createBridge(children, {
+      extensionInfo: {
+        version: "26.409.61251",
+        buildFlavor: "prod",
+        buildNumber: "1555",
+      },
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    const child = children.at(0);
+    expect(child?.writes ?? "").toContain('"version":"26.409.61251"');
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-extension-info",
+      method: "POST",
+      url: "vscode://codex/extension-info",
+    });
+
+    await waitForCondition(() =>
+      emittedMessages.some(
+        (message) =>
+          isBridgeMessage(message, "fetch-response") &&
+          message.requestId === "fetch-extension-info",
+      ),
+    );
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-extension-info")).toEqual({
+      version: "26.409.61251",
+      buildFlavor: "prod",
+      buildNumber: "1555",
+    });
+
+    await bridge.close();
+  });
+
   it("passes the resolved codex home through to the spawned app-server", async () => {
     const codexHomePath = join(tmpdir(), "pocodex-custom-codex-home");
     const bridge = await createBridge(children, {

--- a/test/app-server-bridge-host-config.test.ts
+++ b/test/app-server-bridge-host-config.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildLocalHostConfig, resolveLocalHostKind } from "../src/lib/app-server-bridge.js";
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("local host config helpers", () => {
+  it("builds host config for git-backed workspaces", () => {
+    expect(buildLocalHostConfig("workspace", "git")).toEqual({
+      id: "workspace",
+      display_name: "Local",
+      kind: "git",
+    });
+  });
+
+  it("detects whether a workspace is git-backed", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pocodex-host-kind-"));
+    tempDirectories.push(directory);
+
+    await expect(resolveLocalHostKind(directory)).resolves.toBe("local");
+
+    execFileSync("git", ["init", "-q"], { cwd: directory });
+
+    await expect(resolveLocalHostKind(directory)).resolves.toBe("git");
+  });
+});

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -754,9 +754,11 @@ function createBootstrapHarness(
     },
     getElectronBridge(): {
       sendMessageFromView: (message: unknown) => Promise<void>;
+      getSharedObjectSnapshotValue?: (key: string) => unknown;
     } {
       return Reflect.get(windowObject, "electronBridge") as {
         sendMessageFromView: (message: unknown) => Promise<void>;
+        getSharedObjectSnapshotValue?: (key: string) => unknown;
       };
     },
     emitServerEnvelope(envelope: unknown): void {
@@ -840,6 +842,33 @@ describe("renderBootstrapScript", () => {
         },
       },
     ]);
+  });
+
+  it("seeds shared object snapshots for the current desktop bridge", () => {
+    const harness = createBootstrapHarness();
+    const hostConfig = {
+      id: "workspace",
+      display_name: "Workspace",
+      kind: "git" as const,
+    };
+    const script = renderBootstrapScript({
+      hostConfig,
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    harness.run(script);
+
+    const bridge = harness.getElectronBridge();
+
+    expect(typeof bridge.getSharedObjectSnapshotValue).toBe("function");
+    expect(bridge.getSharedObjectSnapshotValue?.("host_config")).toEqual(hostConfig);
+    expect(bridge.getSharedObjectSnapshotValue?.("remote_connections")).toEqual([]);
   });
 
   it("offers reconnect and reload actions from the connection status overlay", async () => {

--- a/test/codex-desktop-git-worker.test.ts
+++ b/test/codex-desktop-git-worker.test.ts
@@ -201,6 +201,45 @@ describe("DefaultCodexDesktopGitWorkerBridge", () => {
     await bridge.close();
   });
 
+  it("supports the platform-family main RPC method used by current desktop workers", async () => {
+    const bridge = new DefaultCodexDesktopGitWorkerBridge({
+      appPath: "/Applications/Codex.app",
+      resolveWorkerScript: async () => ({
+        workerPath: "/tmp/pocodex-worker.js",
+        metadata: {
+          appPath: "/Applications/Codex.app",
+          buildFlavor: "stable",
+          buildNumber: "123",
+          version: "1.2.3",
+        },
+      }),
+      WorkerClass: FakeWorker as never,
+    });
+
+    await bridge.subscribe();
+
+    const worker = FakeWorker.instances[0];
+    worker?.emit("message", {
+      type: "worker-main-rpc-request",
+      workerId: "git",
+      requestId: "rpc-platform-family",
+      method: "platform-family",
+    });
+
+    expect(worker?.postedMessages.at(-1)).toEqual({
+      type: "worker-main-rpc-response",
+      workerId: "git",
+      requestId: "rpc-platform-family",
+      method: "platform-family",
+      result: {
+        type: "ok",
+        value: process.platform === "win32" ? "windows" : "unix",
+      },
+    });
+
+    await bridge.close();
+  });
+
   it("supports the current desktop worker file-system main RPC methods", async () => {
     const bridge = new DefaultCodexDesktopGitWorkerBridge({
       appPath: "/Applications/Codex.app",

--- a/test/support/app-server-bridge-test-kit.ts
+++ b/test/support/app-server-bridge-test-kit.ts
@@ -251,6 +251,11 @@ export async function createBridge(
   children: MockChildProcess[],
   options: {
     codexHomePath?: string;
+    extensionInfo?: {
+      version: string;
+      buildFlavor: string;
+      buildNumber: string;
+    };
     persistedAtomRegistryPath?: string;
     workspaceRootRegistryPath?: string;
     gitWorkerBridge?: FakeGitWorkerBridge;
@@ -281,6 +286,7 @@ export async function createBridge(
     codexCliPath: "/tmp/mock-codex",
     cwd: TEST_WORKSPACE_ROOT,
     codexHomePath: options.codexHomePath,
+    extensionInfo: options.extensionInfo,
     persistedAtomRegistryPath: options.persistedAtomRegistryPath,
     workspaceRootRegistryPath,
     gitWorkerBridge: options.gitWorkerBridge,


### PR DESCRIPTION
## Summary

This restores the missing Summary tab in Pocodex so the current Codex desktop bundle once again shows the full side-panel tab set for git-backed threads.

## What changed

- plumb the real Codex bundle `version`, `buildFlavor`, and `buildNumber` through `extension-info` so the bundle evaluates the current Summary gate against the correct app identity
- propagate local host kind and `host_config` through the CLI runtime, app-server bridge, and bootstrap payload so the desktop webview sees the workspace as the correct host type during startup
- expose the shared-object snapshot fields and browser bridge compatibility hooks that the current bundle expects, including `host_config`, `remote_connections`, and the newer theme/menu bridge methods
- add the current desktop git-worker `platform-family` RPC support that the newer bundle now calls during its startup flow
- cover the restored bridge and bootstrap contracts with focused regression tests for extension info, host config, shared-object snapshots, and the git-worker RPC

## Root cause

The missing Summary tab came from two newer Codex bundle assumptions that Pocodex was not satisfying:

- Pocodex reported placeholder `extension-info`, so the bundle evaluated the Summary Statsig gate against the wrong app identity
- Pocodex also missed newer desktop compatibility contracts around `host_config`, shared-object snapshots, and the git-worker startup RPCs
- once those startup contracts were incomplete, the side-panel shell did not fully initialize the git-backed thread UI that exposes Summary alongside Review

## Impact

- git-backed thread side panels show `Summary`, `Review`, and `Unstaged` again in Pocodex
- the current desktop bundle gets the extension metadata and host bridge shape it now expects during startup
- focused regressions now cover the restored desktop compatibility surface so future bundle updates are easier to catch

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run test/app-server-bridge-basic.test.ts test/app-server-bridge-host-config.test.ts test/bootstrap-script.test.ts test/codex-desktop-git-worker.test.ts`
- `pnpm exec tsx src/cli.ts --dev --listen 127.0.0.1:8812`
- live local verification on `http://127.0.0.1:8812/` that opening the affected thread and toggling the side panel shows `Summary`, `Review`, and `Unstaged`
