### PR TITLE
Fix: restore Projects and Chats sidebar sections

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 
 import { AppServerBridge } from "./lib/app-server-bridge.js";
 import { normalizeCliArgv } from "./lib/cli-args.js";
+import { readCodexAuthState } from "./lib/codex-auth.js";
 import { loadCodexBundle, resolveDefaultCodexAppPath } from "./lib/codex-bundle.js";
 import { renderBootstrapScript } from "./lib/bootstrap-script.js";
 import { patchIndexHtml } from "./lib/html-patcher.js";
@@ -67,6 +68,11 @@ async function main(): Promise<void> {
   const relay = await AppServerBridge.connect({
     appPath: options.appPath,
     cwd: process.cwd(),
+    extensionInfo: {
+      version: bundle.version,
+      buildFlavor: bundle.buildFlavor,
+      buildNumber: bundle.buildNumber,
+    },
   });
 
   const sentryOptions: SentryInitOptions = {
@@ -84,6 +90,7 @@ async function main(): Promise<void> {
     manifestPath: POCODEX_MANIFEST_HREF,
     iconHref: bundle.faviconHref,
   };
+  const authState = await readCodexAuthState();
 
   const server = new PocodexServer({
     listenHost: options.listenHost,
@@ -96,6 +103,7 @@ async function main(): Promise<void> {
       const indexHtml = await bundle.readIndexHtml();
       return patchIndexHtml(indexHtml, {
         bootstrapScript: renderBootstrapScript({
+          authState,
           devMode: options.devMode,
           sentryOptions,
           stylesheetHref: POCODEX_STYLESHEET_HREF,

--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -45,12 +45,19 @@ import {
 interface AppServerBridgeOptions {
   appPath: string;
   cwd: string;
+  extensionInfo?: AppExtensionInfo;
   hostId?: string;
   codexHomePath?: string;
   persistedAtomRegistryPath?: string;
   workspaceRootRegistryPath?: string;
   gitWorkerBridge?: CodexDesktopGitWorkerBridge;
   codexCliPath?: string;
+}
+
+interface AppExtensionInfo {
+  version: string;
+  buildFlavor: string;
+  buildNumber: string;
 }
 
 interface WhamUsageCredits {
@@ -271,6 +278,7 @@ const LOCAL_UNSUPPORTED_FETCH_BODY = {
 
 export class AppServerBridge extends EventEmitter implements HostBridge {
   private readonly child: ChildProcessWithoutNullStreams;
+  private readonly extensionInfo: AppExtensionInfo;
   private readonly hostId: string;
   private readonly cwd: string;
   private readonly terminalManager: TerminalSessionManager;
@@ -315,6 +323,11 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
 
   private constructor(options: AppServerBridgeOptions) {
     super();
+    this.extensionInfo = options.extensionInfo ?? {
+      version: "0.1.0",
+      buildFlavor: "pocodex",
+      buildNumber: "0",
+    };
     this.hostId = options.hostId ?? "local";
     this.cwd = options.cwd;
     this.codexHomePath = options.codexHomePath ?? deriveCodexHomePath();
@@ -821,7 +834,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       clientInfo: {
         name: "pocodex",
         title: "Pocodex",
-        version: "0.1.0",
+        version: this.extensionInfo.version,
       },
       capabilities: {
         experimentalApi: true,
@@ -1811,11 +1824,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       case "extension-info":
         return {
           status: 200,
-          body: {
-            version: "0.1.0",
-            buildFlavor: "pocodex",
-            buildNumber: "0",
-          },
+          body: this.extensionInfo,
         };
       case "is-copilot-api-available":
         return {

--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -6,6 +6,11 @@ import type {
 import { serializeInlineScript } from "./inline-script.js";
 
 export interface BootstrapScriptConfig {
+  authState?: {
+    accountId: string | null;
+    email: string | null;
+    userId: string | null;
+  } | null;
   devMode?: boolean;
   sentryOptions: SentryInitOptions;
   stylesheetHref: string;
@@ -99,6 +104,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     windowType: "electron";
     sendMessageFromView(message: unknown): Promise<void>;
     getPathForFile(): null;
+    getSharedObjectSnapshotValue?(key: string): unknown;
     sendWorkerMessageFromView(workerName: string, message: unknown): Promise<void>;
     subscribeToWorkerMessages(workerName: string, callback: WorkerMessageListener): () => void;
     showContextMenu(): Promise<void>;
@@ -146,6 +152,18 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
   const workerSubscribers = new Map<string, Set<WorkerMessageListener>>();
   const restorableTerminalAttachments = new Map<string, RestorableTerminalAttachment>();
+  const sharedObjectSnapshots = new Map<string, unknown>([
+    [
+      "host_config",
+      {
+        id: LOCAL_HOST_ID,
+        display_name: "Local",
+        kind: "local",
+      },
+    ],
+    ["pocodex_auth_state", config.authState ?? null],
+    ["remote_connections", []],
+  ]);
   const pendingMessages: string[] = [];
   const toastHost = document.createElement("div");
   const statusHost = document.createElement("div");
@@ -2323,9 +2341,20 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     const overriddenMessage = overrideEnterBehaviorInMessage(message);
     rememberDispatchedEnterBehavior(overriddenMessage);
     syncSidebarModeWithBridgeMessage(overriddenMessage);
+    if (isRecord(overriddenMessage)) {
+      rememberSharedObjectSnapshot(overriddenMessage);
+    }
     syncThreadQueryWithBridgeMessage(overriddenMessage);
     syncRestorableTerminalAttachments(overriddenMessage, "incoming");
     return overriddenMessage;
+  }
+
+  function rememberSharedObjectSnapshot(message: Record<string, unknown>): void {
+    if (message.type !== "shared-object-updated" || typeof message.key !== "string") {
+      return;
+    }
+
+    sharedObjectSnapshots.set(message.key, message.value ?? null);
   }
 
   function overrideEnterBehaviorInMessage(message: Record<string, unknown>): unknown {
@@ -3518,6 +3547,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       }
     },
     getPathForFile: () => null,
+    getSharedObjectSnapshotValue: (key) => sharedObjectSnapshots.get(key) ?? null,
     sendWorkerMessageFromView: async (workerName, message) => {
       sendEnvelope({ type: "worker_message", workerName, message });
     },

--- a/src/lib/codex-auth.ts
+++ b/src/lib/codex-auth.ts
@@ -1,0 +1,114 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { deriveCodexHomePath } from "./codex-home.js";
+
+export interface CodexAuthState {
+  accountId: string | null;
+  email: string | null;
+  userId: string | null;
+}
+
+export async function readCodexAuthState(
+  codexHomePath = deriveCodexHomePath(),
+): Promise<CodexAuthState | null> {
+  try {
+    const authJson = JSON.parse(
+      await readFile(join(codexHomePath, "auth.json"), "utf8"),
+    ) as unknown;
+    if (!isJsonRecord(authJson)) {
+      return null;
+    }
+
+    const tokens = isJsonRecord(authJson.tokens) ? authJson.tokens : null;
+    const accessPayload = decodeJwtPayload(
+      typeof tokens?.access_token === "string" ? tokens.access_token : null,
+    );
+    const idPayload = decodeJwtPayload(
+      typeof tokens?.id_token === "string" ? tokens.id_token : null,
+    );
+    const accessAuth = readOpenAiAuthClaims(accessPayload);
+    const idAuth = readOpenAiAuthClaims(idPayload);
+    const accessProfile = readOpenAiProfileClaims(accessPayload);
+
+    const accountId = firstNonEmptyString(
+      typeof tokens?.account_id === "string" ? tokens.account_id : null,
+      readString(accessAuth?.chatgpt_account_id),
+      readString(idAuth?.chatgpt_account_id),
+    );
+    const userId = firstNonEmptyString(
+      readString(accessAuth?.user_id),
+      readString(accessAuth?.chatgpt_user_id),
+      readString(idAuth?.user_id),
+      readString(idAuth?.chatgpt_user_id),
+    );
+    const email = firstNonEmptyString(
+      readString(accessProfile?.email),
+      readString(idPayload?.email),
+    );
+
+    if (!accountId && !userId && !email) {
+      return null;
+    }
+
+    return {
+      accountId,
+      email,
+      userId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readOpenAiAuthClaims(payload: JsonRecord | null): JsonRecord | null {
+  return isJsonRecord(payload?.["https://api.openai.com/auth"])
+    ? payload["https://api.openai.com/auth"]
+    : null;
+}
+
+function readOpenAiProfileClaims(payload: JsonRecord | null): JsonRecord | null {
+  return isJsonRecord(payload?.["https://api.openai.com/profile"])
+    ? payload["https://api.openai.com/profile"]
+    : null;
+}
+
+function decodeJwtPayload(token: string | null): JsonRecord | null {
+  if (!token) {
+    return null;
+  }
+
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as unknown;
+    return isJsonRecord(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function firstNonEmptyString(...values: Array<string | null>): string | null {
+  for (const value of values) {
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface JsonRecord {
+  [key: string]: unknown;
+}

--- a/src/lib/codex-bundle.ts
+++ b/src/lib/codex-bundle.ts
@@ -71,6 +71,7 @@ const execFileAsync = promisify(execFile);
 export async function loadCodexBundle(appPath: string): Promise<CodexBundle> {
   const metadata = await loadCodexDesktopMetadata(appPath);
   const webviewRoot = await ensureWebviewCache(metadata);
+  await ensurePocodexWebviewPatches(webviewRoot);
   const faviconHref = await resolveWebviewFaviconHref(webviewRoot);
 
   return {
@@ -281,6 +282,58 @@ async function ensureDesktopWorkerCache(metadata: CodexDesktopMetadata): Promise
   }
 
   return workerPath;
+}
+
+async function ensurePocodexWebviewPatches(webviewRoot: string): Promise<void> {
+  const markerPath = join(webviewRoot, ".pocodex-webview-patches-v1");
+  try {
+    await stat(markerPath);
+    return;
+  } catch {
+    // Continue and apply the current patch set.
+  }
+
+  await patchUseAuthBundle(webviewRoot);
+  await writeFile(markerPath, "ok");
+}
+
+async function patchUseAuthBundle(webviewRoot: string): Promise<void> {
+  const assetsDirectory = join(webviewRoot, "assets");
+  const entries = await readdir(assetsDirectory, { withFileTypes: true }).catch(() => []);
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && /^use-auth-.*\.js$/i.test(entry.name))
+      .map(async (entry) => {
+        const assetPath = join(assetsDirectory, entry.name);
+        const source = await readFile(assetPath, "utf8");
+        const patched = patchUseAuthBundleSource(source);
+        if (patched !== source) {
+          await writeFile(assetPath, patched, "utf8");
+        }
+      }),
+  );
+}
+
+function patchUseAuthBundleSource(source: string): string {
+  const snapshotGetter =
+    'window.electronBridge?.getSharedObjectSnapshotValue?.("pocodex_auth_state")';
+  const patchedHookSnippet = `accountId:${snapshotGetter}?.accountId??null,userId:${snapshotGetter}?.userId??null`;
+  const patchedContextReturn = `let t=${snapshotGetter}??null;return t&&typeof t===\`object\`?{...e,accountId:e.accountId??t.accountId??null,email:e.email??t.email??null,userId:e.userId??t.userId??null}:e}`;
+  if (source.includes(patchedHookSnippet) && source.includes(patchedContextReturn)) {
+    return source;
+  }
+
+  let patched = source.replace("accountId:null,userId:null", patchedHookSnippet);
+  patched = patched.replace(
+    "return e}function E(e){return D(s(e))}",
+    `${patchedContextReturn}function E(e){return D(s(e))}`,
+  );
+  patched = patched.replace(
+    "return e}function w(e){return T(s(e))}",
+    `${patchedContextReturn}function w(e){return T(s(e))}`,
+  );
+  return patched;
 }
 
 async function resolveWebviewFaviconHref(webviewRoot: string): Promise<string | null> {

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from "node:events";
 
 import { AppServerBridge } from "./app-server-bridge.js";
 import { renderBootstrapScript } from "./bootstrap-script.js";
+import { readCodexAuthState } from "./codex-auth.js";
 import { loadCodexBundle } from "./codex-bundle.js";
 import { patchIndexHtml } from "./html-patcher.js";
 import { renderPwaHeadTags, renderServiceWorkerScript, renderWebManifest } from "./pwa.js";
@@ -156,6 +157,11 @@ class ManagedPocodexRuntime extends EventEmitter implements PocodexRuntime {
       relay = await AppServerBridge.connect({
         appPath: this.options.appPath,
         cwd: this.options.cwd,
+        extensionInfo: {
+          version: bundle.version,
+          buildFlavor: bundle.buildFlavor,
+          buildNumber: bundle.buildNumber,
+        },
       });
 
       relayErrorListener = (error) => {
@@ -178,6 +184,7 @@ class ManagedPocodexRuntime extends EventEmitter implements PocodexRuntime {
         manifestPath: POCODEX_MANIFEST_HREF,
         iconHref: bundle.faviconHref,
       };
+      const authState = await readCodexAuthState();
 
       server = new PocodexServer({
         listenHost: this.options.listenHost,
@@ -190,6 +197,7 @@ class ManagedPocodexRuntime extends EventEmitter implements PocodexRuntime {
           const indexHtml = await bundle.readIndexHtml();
           return patchIndexHtml(indexHtml, {
             bootstrapScript: renderBootstrapScript({
+              authState,
               devMode: this.options.devMode,
               sentryOptions,
               stylesheetHref: POCODEX_STYLESHEET_HREF,

--- a/test/app-server-bridge-basic.test.ts
+++ b/test/app-server-bridge-basic.test.ts
@@ -105,6 +105,44 @@ describeAppServerBridge(({ children }) => {
     await bridge.close();
   });
 
+  it("reports the desktop bundle extension info to the app-server", async () => {
+    const bridge = await createBridge(children, {
+      extensionInfo: {
+        version: "26.415.20818",
+        buildFlavor: "prod",
+        buildNumber: "1727",
+      },
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "ready",
+    });
+
+    const child = children.at(0);
+    const written = child?.writes ?? "";
+    expect(written).toContain('"version":"26.415.20818"');
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "extension-info",
+      method: "GET",
+      url: "vscode://codex/extension-info",
+    });
+    await waitForCondition(() => Boolean(getFetchResponse(emittedMessages, "extension-info")));
+
+    expect(getFetchJsonBody(emittedMessages, "extension-info")).toEqual({
+      version: "26.415.20818",
+      buildFlavor: "prod",
+      buildNumber: "1727",
+    });
+
+    await bridge.close();
+  });
+
   it("rebroadcasts thread stream state changes back to the browser", async () => {
     const bridge = await createBridge(children);
     const emittedMessages: unknown[] = [];

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -754,9 +754,11 @@ function createBootstrapHarness(
     },
     getElectronBridge(): {
       sendMessageFromView: (message: unknown) => Promise<void>;
+      getSharedObjectSnapshotValue?: (key: string) => unknown;
     } {
       return Reflect.get(windowObject, "electronBridge") as {
         sendMessageFromView: (message: unknown) => Promise<void>;
+        getSharedObjectSnapshotValue?: (key: string) => unknown;
       };
     },
     emitServerEnvelope(envelope: unknown): void {
@@ -927,6 +929,38 @@ describe("renderBootstrapScript", () => {
 
     harness.windowObject.history.replaceState(null, "", "/");
     expect(harness.document.documentElement.dataset.pocodexRoute).toBe("/");
+  });
+
+  it("seeds browser shared-object snapshots for auth state", () => {
+    const harness = createBootstrapHarness();
+    const authState = {
+      accountId: "account-123",
+      email: "dev@example.com",
+      userId: "user-123",
+    };
+    const script = renderBootstrapScript({
+      authState,
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+      importIconSvg: '<svg viewBox="0 0 1 1"></svg>',
+    });
+
+    harness.run(script);
+
+    const bridge = harness.getElectronBridge();
+    expect(typeof bridge.getSharedObjectSnapshotValue).toBe("function");
+    expect(bridge.getSharedObjectSnapshotValue?.("host_config")).toEqual({
+      id: "local",
+      display_name: "Local",
+      kind: "local",
+    });
+    expect(bridge.getSharedObjectSnapshotValue?.("pocodex_auth_state")).toEqual(authState);
+    expect(bridge.getSharedObjectSnapshotValue?.("remote_connections")).toEqual([]);
   });
 
   it("marks the document when the settings shell is present", () => {

--- a/test/codex-auth.test.ts
+++ b/test/codex-auth.test.ts
@@ -1,0 +1,73 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readCodexAuthState } from "../src/lib/codex-auth.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("readCodexAuthState", () => {
+  it("reads account, email, and user identifiers from auth.json tokens", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "pocodex-auth-"));
+    tempDirs.push(codexHome);
+    await mkdir(codexHome, { recursive: true });
+
+    const accessPayload = {
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "account-123",
+        chatgpt_user_id: "user-123",
+      },
+      "https://api.openai.com/profile": {
+        email: "dev@example.com",
+      },
+    };
+    const idPayload = {
+      "https://api.openai.com/auth": {
+        chatgpt_user_id: "user-456",
+      },
+      email: "other@example.com",
+    };
+
+    await writeFile(
+      join(codexHome, "auth.json"),
+      JSON.stringify({
+        tokens: {
+          access_token: createJwt(accessPayload),
+          account_id: "account-123",
+          id_token: createJwt(idPayload),
+        },
+      }),
+      "utf8",
+    );
+
+    await expect(readCodexAuthState(codexHome)).resolves.toEqual({
+      accountId: "account-123",
+      email: "dev@example.com",
+      userId: "user-123",
+    });
+  });
+
+  it("returns null when auth.json does not contain usable identifiers", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "pocodex-auth-"));
+    tempDirs.push(codexHome);
+    await writeFile(join(codexHome, "auth.json"), JSON.stringify({ tokens: {} }), "utf8");
+
+    await expect(readCodexAuthState(codexHome)).resolves.toBeNull();
+  });
+});
+
+function createJwt(payload: unknown): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.`;
+}

--- a/test/codex-bundle.test.ts
+++ b/test/codex-bundle.test.ts
@@ -107,7 +107,11 @@ describe("codex-bundle", () => {
     await mkdir(join(versionCacheRoot, "__cli", "windows-app"), { recursive: true });
     await writeFile(join(versionCacheRoot, "__cli", "windows-app", "codex"), "cached", "utf8");
 
-    asarMock.listPackage.mockReturnValue(["/webview/index.html", "/webview/assets/app-test.png"]);
+    asarMock.listPackage.mockReturnValue([
+      "/webview/index.html",
+      "/webview/assets/app-test.png",
+      "/webview/assets/use-auth-test.js",
+    ]);
     asarMock.statFile.mockReturnValue({ size: 1 });
     asarMock.extractFile.mockImplementation((_appAsarPath, filename) => {
       if (filename === "package.json") {
@@ -126,6 +130,12 @@ describe("codex-bundle", () => {
       if (filename === "webview/assets/app-test.png") {
         return Buffer.from("png");
       }
+      if (filename === "webview/assets/use-auth-test.js") {
+        return Buffer.from(
+          "function T(){let e=(0,p.useContext)(m);if(!e)throw Error(`useAuth must be used within AuthProvider`);return e}function E(e){return D(s(e))}const auth={accountId:null,userId:null};",
+          "utf8",
+        );
+      }
 
       throw new Error(`Unexpected asar extract for ${filename}`);
     });
@@ -136,8 +146,54 @@ describe("codex-bundle", () => {
     expect(bundle.faviconHref).toBe("./assets/app-test.png");
     await expect(bundle.readIndexHtml()).resolves.toBe("<html>codex</html>");
     await expect(
+      readFile(join(bundle.webviewRoot, "assets", "use-auth-test.js"), "utf8"),
+    ).resolves.toContain(
+      'window.electronBridge?.getSharedObjectSnapshotValue?.("pocodex_auth_state")',
+    );
+    await expect(
+      readFile(join(bundle.webviewRoot, "assets", "use-auth-test.js"), "utf8"),
+    ).resolves.toContain("email:e.email??t.email??null");
+    await expect(
       readFile(join(versionCacheRoot, "__cli", "windows-app", "codex"), "utf8"),
     ).resolves.toBe("cached");
+  });
+
+  it("patches an existing cached webview before serving it", async () => {
+    const homeDirectory = await mkdtemp(join(tmpdir(), "pocodex-home-"));
+    tempDirs.push(homeDirectory);
+    process.env.HOME = homeDirectory;
+
+    const appPath = await createWindowsInstallLayout();
+    const webviewRoot = join(
+      homeDirectory,
+      ".cache",
+      "pocodex",
+      "26.313.5234.0__prod__5234",
+      "__webview",
+    );
+    await mkdir(join(webviewRoot, "assets"), { recursive: true });
+    await writeFile(join(webviewRoot, ".complete"), "ok", "utf8");
+    await writeFile(join(webviewRoot, "index.html"), "<html>cached</html>", "utf8");
+    await writeFile(
+      join(webviewRoot, "assets", "use-auth-test.js"),
+      "function T(){let e=(0,p.useContext)(m);if(!e)throw Error(`useAuth must be used within AuthProvider`);return e}function E(e){return D(s(e))}const auth={accountId:null,userId:null};",
+      "utf8",
+    );
+
+    const bundle = await loadCodexBundle(appPath);
+
+    expect(bundle.webviewRoot).toBe(webviewRoot);
+    await expect(
+      readFile(join(webviewRoot, "assets", "use-auth-test.js"), "utf8"),
+    ).resolves.toContain(
+      'window.electronBridge?.getSharedObjectSnapshotValue?.("pocodex_auth_state")',
+    );
+    await expect(
+      readFile(join(webviewRoot, "assets", "use-auth-test.js"), "utf8"),
+    ).resolves.toContain("email:e.email??t.email??null");
+    await expect(readFile(join(webviewRoot, ".pocodex-webview-patches-v1"), "utf8")).resolves.toBe(
+      "ok",
+    );
   });
 
   it("separates cached artifacts for builds that share a version string", async () => {

--- a/test/support/app-server-bridge-test-kit.ts
+++ b/test/support/app-server-bridge-test-kit.ts
@@ -251,6 +251,11 @@ export async function createBridge(
   children: MockChildProcess[],
   options: {
     codexHomePath?: string;
+    extensionInfo?: {
+      version: string;
+      buildFlavor: string;
+      buildNumber: string;
+    };
     persistedAtomRegistryPath?: string;
     workspaceRootRegistryPath?: string;
     gitWorkerBridge?: FakeGitWorkerBridge;
@@ -281,6 +286,7 @@ export async function createBridge(
     codexCliPath: "/tmp/mock-codex",
     cwd: TEST_WORKSPACE_ROOT,
     codexHomePath: options.codexHomePath,
+    extensionInfo: options.extensionInfo,
     persistedAtomRegistryPath: options.persistedAtomRegistryPath,
     workspaceRootRegistryPath,
     gitWorkerBridge: options.gitWorkerBridge,


### PR DESCRIPTION
## Summary

This restores separate `Projects` and `Chats` sections in Pocodex so project-backed conversations once again render under `Projects`, matching desktop Codex.

## What changed

- read Codex auth identifiers from `~/.codex/auth.json` and pass that auth state into the browser bootstrap payload
- seed `pocodex_auth_state`, `host_config`, and `remote_connections` into the shared-object snapshot bridge that the current desktop webview reads during startup
- patch extracted and cached `use-auth` webview assets so the bundle reads `accountId`, `email`, and `userId` from the Pocodex bridge instead of hardcoded `null` values
- pass the real desktop `version`, `buildFlavor`, and `buildNumber` through the CLI/runtime and `vscode://codex/extension-info` bridge path
- add focused regression coverage for auth parsing, bootstrap shared-object snapshots, extension info plumbing, and the webview auth patch path

## Root cause

- Pocodex left the desktop auth snapshot empty, so the current `use-auth` bundle fed `null` account and user identifiers into the webview
- Pocodex also returned placeholder `extension-info`, so the current bundle evaluated its grouping gate against the wrong app identity
- once those startup contracts were wrong, project-backed conversations fell through into the `Chats` list instead of rendering under `Projects`

## Impact

- project folders render under `Projects` again and `Chats` stays separate
- the current desktop bundle receives the auth and extension metadata it expects during startup
- focused regressions now cover the restored auth/bootstrap contract and patched webview path

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run test/app-server-bridge-basic.test.ts test/bootstrap-script.test.ts test/codex-bundle.test.ts test/codex-auth.test.ts`
- `pnpm run build`
- `node dist/cli.js --dev --listen 127.0.0.1:8822`
- live local verification on `http://127.0.0.1:8822/` that the left sidebar shows `Projects` with project folders underneath and a separate `Chats` section with `No chats`
