### PR TITLE
Fix: restore the Review file tree

### DIFF
--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -1039,6 +1039,122 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     };
   }
 
+  private async listWorkspaceDirectoryEntries(body: unknown): Promise<{
+    directoryPath: string;
+    entries: Array<{
+      name: string;
+      path: string;
+      type: "directory" | "file";
+    }>;
+  }> {
+    const params = readCodexFetchParams(body);
+    if (!isJsonRecord(params)) {
+      throw new Error("Missing workspace directory entries params.");
+    }
+
+    const workspaceRoot = await this.resolveWorkspaceRootPickerDirectoryPath(
+      {
+        path: typeof params.workspaceRoot === "string" ? params.workspaceRoot : "",
+      },
+      {
+        fallbackToHome: false,
+        pathKey: "path",
+      },
+    );
+    const requestedDirectoryPath =
+      typeof params.directoryPath === "string" && params.directoryPath.trim().length > 0
+        ? params.directoryPath.trim()
+        : workspaceRoot;
+    const directoryPathCandidate = isAbsolute(requestedDirectoryPath)
+      ? requestedDirectoryPath
+      : join(workspaceRoot, requestedDirectoryPath);
+    const directoryPath = await this.resolveWorkspaceRootPickerDirectoryPath(
+      {
+        path: directoryPathCandidate,
+      },
+      {
+        fallbackToHome: false,
+        pathKey: "path",
+      },
+    );
+    const relativeDirectoryPath = relative(workspaceRoot, directoryPath);
+    if (
+      relativeDirectoryPath === ".." ||
+      relativeDirectoryPath.startsWith("../") ||
+      isAbsolute(relativeDirectoryPath)
+    ) {
+      throw new Error("Directory path must stay within the selected workspace root.");
+    }
+
+    const includeHidden = params.includeHidden === true;
+    const dirents = await readdir(directoryPath, {
+      withFileTypes: true,
+    });
+    const entries: Array<{
+      name: string;
+      path: string;
+      type: "directory" | "file";
+    }> = [];
+
+    for (const dirent of dirents) {
+      if (!includeHidden && dirent.name.startsWith(".")) {
+        continue;
+      }
+
+      const entryPath = join(directoryPath, dirent.name);
+      const workspaceRelativeEntryPath = relative(workspaceRoot, entryPath).replaceAll("\\", "/");
+      if (dirent.isDirectory()) {
+        entries.push({
+          name: dirent.name,
+          path: workspaceRelativeEntryPath,
+          type: "directory",
+        });
+        continue;
+      }
+
+      if (dirent.isFile()) {
+        entries.push({
+          name: dirent.name,
+          path: workspaceRelativeEntryPath,
+          type: "file",
+        });
+        continue;
+      }
+
+      if (!dirent.isSymbolicLink()) {
+        continue;
+      }
+
+      try {
+        const stats = await stat(entryPath);
+        if (stats.isDirectory()) {
+          entries.push({
+            name: dirent.name,
+            path: workspaceRelativeEntryPath,
+            type: "directory",
+          });
+          continue;
+        }
+        if (stats.isFile()) {
+          entries.push({
+            name: dirent.name,
+            path: workspaceRelativeEntryPath,
+            type: "file",
+          });
+        }
+      } catch {
+        // Ignore broken or inaccessible symlinks in the workspace browser.
+      }
+    }
+
+    entries.sort((left, right) => compareWorkspaceDirectoryEntries(left, right));
+
+    return {
+      directoryPath: relativeDirectoryPath.replaceAll("\\", "/"),
+      entries,
+    };
+  }
+
   private emitConnectionState(): void {
     this.emit("bridge_message", {
       type: "codex-app-server-connection-changed",
@@ -1796,6 +1912,20 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
             labels: Object.fromEntries(this.workspaceRootLabels),
           },
         };
+      case "workspace-directory-entries":
+        try {
+          return {
+            status: 200,
+            body: await this.listWorkspaceDirectoryEntries(body),
+          };
+        } catch (error) {
+          return {
+            status: 400,
+            body: {
+              error: normalizeError(error).message,
+            },
+          };
+        }
       case "add-workspace-root-option":
         return {
           status: 200,
@@ -1892,6 +2022,8 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
           status: 200,
           body: await this.writeCodexAgentsMarkdown(body),
         };
+      case "read-file-metadata":
+        return await this.readCodexFileMetadata(body);
       case "read-file":
         return await this.readCodexFile(body);
       case "list-automations":
@@ -2526,6 +2658,62 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
   }
 
+  private async readCodexFileMetadata(body: unknown): Promise<RelativeFetchResponse> {
+    const path = readCodexFilePath(body);
+    if (!path) {
+      return {
+        status: 400,
+        body: {
+          error: "File path is required.",
+        },
+      };
+    }
+
+    let resolvedPath: string;
+    try {
+      resolvedPath = normalizeCodexReadFilePath(path);
+    } catch (error) {
+      return {
+        status: 400,
+        body: {
+          error: normalizeError(error).message,
+        },
+      };
+    }
+
+    try {
+      const stats = await stat(resolvedPath);
+      return {
+        status: 200,
+        body: {
+          path: resolvedPath,
+          isFile: stats.isFile(),
+          ...(stats.isFile() ? { sizeBytes: stats.size } : {}),
+        },
+      };
+    } catch (error) {
+      if (isFileNotFoundError(error)) {
+        return {
+          status: 404,
+          body: {
+            error: "File not found.",
+          },
+        };
+      }
+
+      if (isPermissionDeniedError(error)) {
+        return {
+          status: 403,
+          body: {
+            error: "File is not readable.",
+          },
+        };
+      }
+
+      throw error;
+    }
+  }
+
   private readDeveloperInstructions(body: unknown): string | null {
     if (!isJsonRecord(body)) {
       return null;
@@ -3101,6 +3289,26 @@ function compareWorkspaceRootBrowserEntries(
   left: { name: string },
   right: { name: string },
 ): number {
+  const leftHidden = left.name.startsWith(".");
+  const rightHidden = right.name.startsWith(".");
+  if (leftHidden !== rightHidden) {
+    return leftHidden ? 1 : -1;
+  }
+
+  return left.name.localeCompare(right.name, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+function compareWorkspaceDirectoryEntries(
+  left: { name: string; type: "directory" | "file" },
+  right: { name: string; type: "directory" | "file" },
+): number {
+  if (left.type !== right.type) {
+    return left.type === "directory" ? -1 : 1;
+  }
+
   const leftHidden = left.name.startsWith(".");
   const rightHidden = right.name.startsWith(".");
   if (leftHidden !== rightHidden) {

--- a/test/app-server-bridge-host-data.test.ts
+++ b/test/app-server-bridge-host-data.test.ts
@@ -338,6 +338,44 @@ description: Review lint issues quickly.
     await bridge.close();
   });
 
+  it("reads file metadata through the webview contract", async () => {
+    const skillDirectory = await mkdtemp(join(tmpdir(), "pocodex-skill-"));
+    tempDirs.push(skillDirectory);
+    const skillPath = join(skillDirectory, "SKILL.md");
+    const skillContents = "# Demo Skill\n\nUse concise output.\n";
+    await writeFile(skillPath, skillContents, "utf8");
+
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-read-file-metadata",
+      method: "POST",
+      url: "vscode://codex/read-file-metadata",
+      body: JSON.stringify({
+        params: {
+          path: skillPath,
+        },
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-read-file-metadata")),
+    );
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-read-file-metadata")).toEqual({
+      path: skillPath,
+      isFile: true,
+      sizeBytes: Buffer.byteLength(skillContents, "utf8"),
+    });
+
+    await bridge.close();
+  });
+
   it("returns a fetch error for invalid read-file paths", async () => {
     const bridge = await createBridge(children);
     const emittedMessages: unknown[] = [];

--- a/test/app-server-bridge-workspace.test.ts
+++ b/test/app-server-bridge-workspace.test.ts
@@ -155,6 +155,139 @@ describeAppServerBridge(({ children }) => {
     await secondBridge.close();
   });
 
+  it("lists workspace directory entries for the local workspace browser", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-workspace-browser-"));
+    tempDirs.push(tempDirectory);
+    const emptyDirectory = join(tempDirectory, "empty-dir");
+    const sourceDirectory = join(tempDirectory, "src");
+    await mkdir(emptyDirectory, { recursive: true });
+    await mkdir(sourceDirectory, { recursive: true });
+    await writeFile(join(tempDirectory, "README.md"), "fixture\n", "utf8");
+    await writeFile(join(tempDirectory, ".env"), "SECRET=value\n", "utf8");
+    await writeFile(join(sourceDirectory, "index.ts"), "export {};\n", "utf8");
+    await writeFile(join(sourceDirectory, ".secret.ts"), "export const hidden = true;\n", "utf8");
+
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-workspace-directory-root",
+      method: "POST",
+      url: "vscode://codex/workspace-directory-entries",
+      body: JSON.stringify({
+        params: {
+          workspaceRoot: tempDirectory,
+          includeHidden: false,
+        },
+      }),
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-workspace-directory-nested",
+      method: "POST",
+      url: "vscode://codex/workspace-directory-entries",
+      body: JSON.stringify({
+        params: {
+          workspaceRoot: tempDirectory,
+          directoryPath: "src",
+          includeHidden: true,
+        },
+      }),
+    });
+
+    await waitForCondition(
+      () =>
+        Boolean(getFetchResponse(emittedMessages, "fetch-workspace-directory-root")) &&
+        Boolean(getFetchResponse(emittedMessages, "fetch-workspace-directory-nested")),
+    );
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-workspace-directory-root")).toEqual({
+      directoryPath: "",
+      entries: [
+        {
+          name: "empty-dir",
+          path: "empty-dir",
+          type: "directory",
+        },
+        {
+          name: "src",
+          path: "src",
+          type: "directory",
+        },
+        {
+          name: "README.md",
+          path: "README.md",
+          type: "file",
+        },
+      ],
+    });
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-workspace-directory-nested")).toEqual({
+      directoryPath: "src",
+      entries: [
+        {
+          name: "index.ts",
+          path: "src/index.ts",
+          type: "file",
+        },
+        {
+          name: ".secret.ts",
+          path: "src/.secret.ts",
+          type: "file",
+        },
+      ],
+    });
+
+    await bridge.close();
+  });
+
+  it("rejects workspace directory requests outside the selected workspace root", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-workspace-browser-"));
+    tempDirs.push(tempDirectory);
+    const sourceDirectory = join(tempDirectory, "src");
+    await mkdir(sourceDirectory, { recursive: true });
+
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-workspace-directory-outside-root",
+      method: "POST",
+      url: "vscode://codex/workspace-directory-entries",
+      body: JSON.stringify({
+        params: {
+          workspaceRoot: sourceDirectory,
+          directoryPath: dirname(tempDirectory),
+        },
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-workspace-directory-outside-root")),
+    );
+
+    expect(
+      getFetchResponse(emittedMessages, "fetch-workspace-directory-outside-root"),
+    ).toMatchObject({
+      type: "fetch-response",
+      requestId: "fetch-workspace-directory-outside-root",
+      responseType: "error",
+      status: 400,
+      error: "Directory path must stay within the selected workspace root.",
+    });
+
+    await bridge.close();
+  });
+
   it("persists host persisted atoms across restarts", async () => {
     const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-persisted-atoms-"));
     tempDirs.push(tempDirectory);


### PR DESCRIPTION
## Summary

This restores the Review side panel's `All files` tree in Pocodex so the current Codex desktop bundle can list workspace files and open them from the tree again.

## What changed

- add `vscode://codex/workspace-directory-entries` handling in the app-server bridge for the Review file tree
- resolve nested `directoryPath` requests against the selected workspace root, reject escapes outside that root, and return workspace-relative entry paths that match the current bundle contract
- add `vscode://codex/read-file-metadata` support with the `path`, `isFile`, and `sizeBytes` fields the Review file tab expects before loading file contents
- add focused regression coverage for root and nested workspace directory listings, hidden-file handling, outside-root rejection, and the read-file metadata contract

## Root cause

- Pocodex did not implement `vscode://codex/workspace-directory-entries`, so the current Codex bundle could not populate the `All files` tree in the Review side panel
- the Review tree also expects workspace-relative entry paths; absolute paths do not build the visible tree correctly
- after the tree could render, clicking a file still failed because Pocodex did not implement `vscode://codex/read-file-metadata`, so the bundle stopped before calling `read-file`

## Impact

- `Review` -> `All files` shows the workspace file tree again in Pocodex
- clicking files from that tree opens their contents again instead of showing `Unable to load file`
- focused regressions now cover the listing and metadata bridge contracts the current desktop bundle depends on

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run ./test/app-server-bridge-host-data.test.ts ./test/app-server-bridge-workspace.test.ts`
- `pnpm exec tsx src/cli.ts --dev --listen 127.0.0.1:8798`
- live local verification on `http://127.0.0.1:8798/` that `Review` -> `All files` renders the repo tree and opening `README.md` no longer shows `Unable to load file`
