### PR TITLE
Fix: restore Add photos & files in Pocodex

### DIFF
--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -80,6 +80,18 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     entries: WorkspaceRootBrowserEntry[];
   };
 
+  type BrowserAttachmentPickerOptions = {
+    imagesOnly?: boolean;
+    pickerTitle?: string;
+  };
+
+  type BrowserAttachmentFile = {
+    label: string;
+    path: string;
+    fsPath: string;
+    contentsBase64?: string;
+  };
+
   type RestorableTerminalAttachment = {
     sessionId: string;
     conversationId: string | null;
@@ -127,6 +139,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   const LEGACY_SIDEBAR_MODE_PERSISTED_ATOM_KEY = "pocodex-sidebar-mode";
   const SIDEBAR_INTERACTION_ARM_MS = 500;
   const SIDEBAR_MODE_TOGGLE_SETTLE_MS = 350;
+  const BROWSER_ATTACHMENT_PICKER_CANCEL_DELAY_MS = 250;
   const HEARTBEAT_STALE_AFTER_MS = 45_000;
   const HEARTBEAT_MONITOR_INTERVAL_MS = 5_000;
   const WAKE_GRACE_PERIOD_MS = 10_000;
@@ -1988,6 +2001,128 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     return { ok: true };
   }
 
+  async function pickBrowserAttachmentFiles(
+    options: BrowserAttachmentPickerOptions = {},
+  ): Promise<BrowserAttachmentFile[]> {
+    return new Promise((resolve) => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.multiple = true;
+      input.tabIndex = -1;
+      input.style.position = "fixed";
+      input.style.left = "-9999px";
+      input.style.top = "-9999px";
+      input.style.opacity = "0";
+      if (options.imagesOnly) {
+        input.accept = "image/*";
+      }
+      if (options.pickerTitle) {
+        input.title = options.pickerTitle;
+      }
+
+      let settled = false;
+      const cleanup = () => {
+        window.removeEventListener("focus", handleWindowFocus, true);
+        input.remove();
+      };
+      const settle = (files: BrowserAttachmentFile[]) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(files);
+      };
+      const handleWindowFocus = () => {
+        window.setTimeout(() => {
+          if (settled || (input.files?.length ?? 0) > 0) {
+            return;
+          }
+          settle([]);
+        }, BROWSER_ATTACHMENT_PICKER_CANCEL_DELAY_MS);
+      };
+
+      input.addEventListener(
+        "change",
+        () => {
+          void buildBrowserAttachmentFiles(Array.from(input.files ?? []))
+            .then(settle)
+            .catch(() => {
+              settle([]);
+            });
+        },
+        { once: true },
+      );
+      window.addEventListener("focus", handleWindowFocus, true);
+      (document.body ?? document.documentElement).appendChild(input);
+      input.click();
+    });
+  }
+
+  async function buildBrowserAttachmentFiles(files: File[]): Promise<BrowserAttachmentFile[]> {
+    const pickedFiles: BrowserAttachmentFile[] = [];
+    for (const file of files) {
+      const normalizedName = file.name.trim();
+      if (normalizedName.length === 0) {
+        continue;
+      }
+
+      const browserFile: BrowserAttachmentFile = {
+        label: buildBrowserAttachmentLabel(normalizedName),
+        path: normalizedName,
+        fsPath: normalizedName,
+      };
+
+      if (isBrowserAttachmentImage(file)) {
+        const contentsBase64 = await readBrowserAttachmentFileBase64(file);
+        if (contentsBase64) {
+          browserFile.contentsBase64 = contentsBase64;
+        }
+      }
+
+      pickedFiles.push(browserFile);
+    }
+    return pickedFiles;
+  }
+
+  function buildBrowserAttachmentLabel(filename: string): string {
+    const extensionIndex = filename.lastIndexOf(".");
+    if (extensionIndex > 0) {
+      return filename.slice(0, extensionIndex);
+    }
+    return filename;
+  }
+
+  function isBrowserAttachmentImage(file: File): boolean {
+    return (
+      /^image\//i.test(file.type) ||
+      /\.(?:avif|bmp|gif|heic|heif|ico|jpe?g|png|svg|tiff?|webp)$/i.test(file.name)
+    );
+  }
+
+  async function readBrowserAttachmentFileBase64(file: File): Promise<string | null> {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.addEventListener(
+        "load",
+        () => {
+          const result = typeof reader.result === "string" ? reader.result : "";
+          const commaIndex = result.indexOf(",");
+          resolve(commaIndex >= 0 ? result.slice(commaIndex + 1) : null);
+        },
+        { once: true },
+      );
+      reader.addEventListener(
+        "error",
+        () => {
+          resolve(null);
+        },
+        { once: true },
+      );
+      reader.readAsDataURL(file);
+    });
+  }
+
   function stopEventPropagation(event: unknown): void {
     if (isRecord(event) && typeof event.stopImmediatePropagation === "function") {
       event.stopImmediatePropagation();
@@ -3570,6 +3705,12 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     value: electronBridge,
     configurable: false,
     enumerable: true,
+    writable: false,
+  });
+  Object.defineProperty(window, "__pocodexBrowserPickFiles", {
+    value: pickBrowserAttachmentFiles,
+    configurable: false,
+    enumerable: false,
     writable: false,
   });
 

--- a/src/lib/codex-bundle.ts
+++ b/src/lib/codex-bundle.ts
@@ -71,6 +71,7 @@ const execFileAsync = promisify(execFile);
 export async function loadCodexBundle(appPath: string): Promise<CodexBundle> {
   const metadata = await loadCodexDesktopMetadata(appPath);
   const webviewRoot = await ensureWebviewCache(metadata);
+  await ensurePocodexWebviewPatches(webviewRoot);
   const faviconHref = await resolveWebviewFaviconHref(webviewRoot);
 
   return {
@@ -281,6 +282,70 @@ async function ensureDesktopWorkerCache(metadata: CodexDesktopMetadata): Promise
   }
 
   return workerPath;
+}
+
+async function ensurePocodexWebviewPatches(webviewRoot: string): Promise<void> {
+  const markerPath = join(webviewRoot, ".pocodex-webview-patches-v1");
+  try {
+    await stat(markerPath);
+    return;
+  } catch {
+    // continue and patch the webview assets
+  }
+
+  await patchAttachmentPickerBundle(webviewRoot);
+  await writeFile(markerPath, "ok");
+}
+
+async function patchAttachmentPickerBundle(webviewRoot: string): Promise<void> {
+  const assetsDirectory = join(webviewRoot, "assets");
+  const entries = await readdir(assetsDirectory, { withFileTypes: true }).catch(() => []);
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && /\.js$/i.test(entry.name))
+      .map(async (entry) => {
+        const assetPath = join(assetsDirectory, entry.name);
+        const source = await readFile(assetPath, "utf8");
+        const patched = patchAttachmentPickerBundleSource(source);
+        if (patched !== source) {
+          await writeFile(assetPath, patched, "utf8");
+        }
+      }),
+  );
+}
+
+function patchAttachmentPickerBundleSource(source: string): string {
+  if (
+    !source.includes("pick-files") ||
+    !source.includes("composer.addContext.openFilePickerError")
+  ) {
+    return source;
+  }
+
+  let patched = source;
+
+  patched = patched.replace(
+    /if\(([$A-Za-z_][\w$]*)===([`'"])browser\2\)\{([A-Za-z_$][\w$]*)\.current\?\.click\(\);return\}/,
+    (_match, windowTypeVariable: string, quote: string, inputRefVariable: string) =>
+      `if(${windowTypeVariable}===${quote}browser${quote}||window.location.protocol!==${quote}file:${quote}){${inputRefVariable}.current?.click();return}`,
+  );
+
+  if (!patched.includes("__pocodexBrowserPickFiles")) {
+    patched = patched.replace(
+      "(await Se(`pick-files`,{params:{...t?{imagesOnly:!0}:{},pickerTitle:n}})).files??[]",
+      "((window.location.protocol!==`file:`&&typeof window.__pocodexBrowserPickFiles===`function`?await window.__pocodexBrowserPickFiles({imagesOnly:t,pickerTitle:n}):(await Se(`pick-files`,{params:{...t?{imagesOnly:!0}:{},pickerTitle:n}})).files)??[])",
+    );
+  }
+
+  if (!patched.includes("e.contentsBase64?{contentsBase64:e.contentsBase64}")) {
+    patched = patched.replace(
+      "let t=await Se(`read-file-binary`,{params:{path:e.fsPath,hostId:N}});",
+      "let t=e.contentsBase64?{contentsBase64:e.contentsBase64}:await Se(`read-file-binary`,{params:{path:e.fsPath,hostId:N}});",
+    );
+  }
+
+  return patched;
 }
 
 async function resolveWebviewFaviconHref(webviewRoot: string): Promise<string | null> {

--- a/test/codex-bundle.test.ts
+++ b/test/codex-bundle.test.ts
@@ -107,7 +107,12 @@ describe("codex-bundle", () => {
     await mkdir(join(versionCacheRoot, "__cli", "windows-app"), { recursive: true });
     await writeFile(join(versionCacheRoot, "__cli", "windows-app", "codex"), "cached", "utf8");
 
-    asarMock.listPackage.mockReturnValue(["/webview/index.html", "/webview/assets/app-test.png"]);
+    asarMock.listPackage.mockReturnValue([
+      "/webview/index.html",
+      "/webview/assets/app-test.png",
+      "/webview/assets/index-test.js",
+      "/webview/assets/use-model-settings-test.js",
+    ]);
     asarMock.statFile.mockReturnValue({ size: 1 });
     asarMock.extractFile.mockImplementation((_appAsarPath, filename) => {
       if (filename === "package.json") {
@@ -126,6 +131,18 @@ describe("codex-bundle", () => {
       if (filename === "webview/assets/app-test.png") {
         return Buffer.from("png");
       }
+      if (filename === "webview/assets/index-test.js") {
+        return Buffer.from(
+          "function GQ(){let b=`electron`,_=null;if(b===`browser`){_.current?.click();return}try{return Xn(`pick-files`,{params:{pickerTitle:`Select files`}})}catch{throw new Error(`composer.addContext.openFilePickerError: Unable to open file picker`)}}",
+          "utf8",
+        );
+      }
+      if (filename === "webview/assets/use-model-settings-test.js") {
+        return Buffer.from(
+          "function jE(){return async({imagesOnly:t,pickerTitle:n=`Select files`}={})=>(await Se(`pick-files`,{params:{...t?{imagesOnly:!0}:{},pickerTitle:n}})).files??[]}async function H(e){return(await Promise.all(e.map(async e=>{try{let t=await Se(`read-file-binary`,{params:{path:e.fsPath,hostId:N}});if(!t.contentsBase64)return null;return{dataUrl:t.contentsBase64,filename:e.label}}catch{return null}}))).filter(e=>e!=null)}function V(){try{return jE()}catch{throw new Error(`composer.addContext.openFilePickerError: Unable to open file picker`)}}",
+          "utf8",
+        );
+      }
 
       throw new Error(`Unexpected asar extract for ${filename}`);
     });
@@ -136,8 +153,62 @@ describe("codex-bundle", () => {
     expect(bundle.faviconHref).toBe("./assets/app-test.png");
     await expect(bundle.readIndexHtml()).resolves.toBe("<html>codex</html>");
     await expect(
+      readFile(join(bundle.webviewRoot, "assets", "index-test.js"), "utf8"),
+    ).resolves.toContain("window.location.protocol!==`file:`");
+    await expect(
+      readFile(join(bundle.webviewRoot, "assets", "use-model-settings-test.js"), "utf8"),
+    ).resolves.toContain("__pocodexBrowserPickFiles");
+    await expect(
+      readFile(join(bundle.webviewRoot, "assets", "use-model-settings-test.js"), "utf8"),
+    ).resolves.toContain("e.contentsBase64?{contentsBase64:e.contentsBase64}");
+    await expect(
+      readFile(join(bundle.webviewRoot, ".pocodex-webview-patches-v1"), "utf8"),
+    ).resolves.toBe("ok");
+    await expect(
       readFile(join(versionCacheRoot, "__cli", "windows-app", "codex"), "utf8"),
     ).resolves.toBe("cached");
+  });
+
+  it("patches an existing cached webview in place", async () => {
+    const homeDirectory = await mkdtemp(join(tmpdir(), "pocodex-home-"));
+    tempDirs.push(homeDirectory);
+    process.env.HOME = homeDirectory;
+
+    const appPath = await createWindowsInstallLayout();
+    const versionCacheRoot = join(homeDirectory, ".cache", "pocodex", "26.313.5234.0__prod__5234");
+    const webviewRoot = join(versionCacheRoot, "__webview");
+    await mkdir(join(webviewRoot, "assets"), { recursive: true });
+    await writeFile(join(webviewRoot, ".complete"), "ok", "utf8");
+    await writeFile(join(webviewRoot, "index.html"), "<html>cached</html>", "utf8");
+    await writeFile(join(webviewRoot, "assets", "app-test.png"), "png", "utf8");
+    await writeFile(
+      join(webviewRoot, "assets", "index-test.js"),
+      "function GQ(){let b=`electron`,_=null;if(b===`browser`){_.current?.click();return}try{return Xn(`pick-files`,{params:{pickerTitle:`Select files`}})}catch{throw new Error(`composer.addContext.openFilePickerError: Unable to open file picker`)}}",
+      "utf8",
+    );
+    await writeFile(
+      join(webviewRoot, "assets", "use-model-settings-test.js"),
+      "function jE(){return async({imagesOnly:t,pickerTitle:n=`Select files`}={})=>(await Se(`pick-files`,{params:{...t?{imagesOnly:!0}:{},pickerTitle:n}})).files??[]}async function H(e){return(await Promise.all(e.map(async e=>{try{let t=await Se(`read-file-binary`,{params:{path:e.fsPath,hostId:N}});if(!t.contentsBase64)return null;return{dataUrl:t.contentsBase64,filename:e.label}}catch{return null}}))).filter(e=>e!=null)}function V(){try{return jE()}catch{throw new Error(`composer.addContext.openFilePickerError: Unable to open file picker`)}}",
+      "utf8",
+    );
+
+    const bundle = await loadCodexBundle(appPath);
+
+    expect(bundle.webviewRoot).toBe(webviewRoot);
+    expect(bundle.faviconHref).toBe("./assets/app-test.png");
+    await expect(bundle.readIndexHtml()).resolves.toBe("<html>cached</html>");
+    await expect(readFile(join(webviewRoot, "assets", "index-test.js"), "utf8")).resolves.toContain(
+      "window.location.protocol!==`file:`",
+    );
+    await expect(
+      readFile(join(webviewRoot, "assets", "use-model-settings-test.js"), "utf8"),
+    ).resolves.toContain("__pocodexBrowserPickFiles");
+    await expect(
+      readFile(join(webviewRoot, "assets", "use-model-settings-test.js"), "utf8"),
+    ).resolves.toContain("e.contentsBase64?{contentsBase64:e.contentsBase64}");
+    await expect(readFile(join(webviewRoot, ".pocodex-webview-patches-v1"), "utf8")).resolves.toBe(
+      "ok",
+    );
   });
 
   it("separates cached artifacts for builds that share a version string", async () => {


### PR DESCRIPTION
## Summary

This restores `Add photos & files` in Pocodex so browser sessions open a working file chooser again and attach the selected files instead of failing with `Unable to open file picker`.

## What changed

- add a browser-side attachment picker helper in the bootstrap script that returns the selected files in the shape the current Codex bundle expects
- patch extracted and cached webview attachment assets so non-`file:` browser sessions use that helper instead of the native `pick-files` route
- reuse in-memory image bytes for browser-picked image attachments so the bundle does not fall back to `read-file-binary` on files that only exist in the browser chooser
- add focused regression coverage for both freshly extracted and already cached webview bundles

## Root cause

- Pocodex only handled the older hidden-input attachment path, but the current desktop bundle moved `Add photos & files` into a bundled `pick-files` flow
- in browser-served Pocodex, that native `pick-files` route is unsupported, so the composer surfaced `Unable to open file picker`
- image attachments also needed a browser-safe byte path because the bundle otherwise tried to read chooser-only files through the native binary file bridge

## Impact

- `Add photos & files` opens a real browser file chooser again in Pocodex
- regular files and images attach to the composer without the picker error
- regression coverage now protects the extracted and cached webview patch paths this fix depends on

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run test/codex-bundle.test.ts`
- `pnpm exec tsx src/cli.ts --dev --listen 127.0.0.1:8799`
- live local verification on `http://127.0.0.1:8799/` that `Add photos & files` attaches `README.md` and `artifacts/icon.png` as composer chips without showing `Unable to open file picker`
