### PR TITLE
Fix: restore new chat startup flow

### DIFF
--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -131,7 +131,7 @@ interface ManagedCodexAuth {
 }
 
 interface AppServerMcpRequestEnvelope {
-  type: "mcp-request";
+  type: "mcp-request" | "thread-prewarm-start";
   request?: JsonRpcRequest;
 }
 
@@ -502,6 +502,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
         await this.handleRenameWorkspaceRootOption(message);
         return;
       case "mcp-request":
+      case "thread-prewarm-start":
         await this.handleMcpRequest(message as unknown as AppServerMcpRequestEnvelope);
         return;
       case "mcp-response":

--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -674,12 +674,17 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     }
 
     const ariaLabel = element.getAttribute("aria-label")?.trim().toLowerCase() ?? "";
-    if (ariaLabel === "new thread" || ariaLabel.startsWith("start new thread in ")) {
+    if (
+      ariaLabel === "new thread" ||
+      ariaLabel === "new chat" ||
+      ariaLabel.startsWith("start new thread in ") ||
+      ariaLabel.startsWith("start new chat in ")
+    ) {
       return true;
     }
 
-    const text = element.textContent?.trim().toLowerCase() ?? "";
-    return text === "new thread";
+    const text = element.textContent?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
+    return text.startsWith("new thread") || text.startsWith("new chat");
   }
 
   function isAddPhotosAndFilesMenuItem(element: Element): boolean {
@@ -2954,11 +2959,16 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
   function restoreStoredRouteIfNeeded(): void {
     const currentUrl = new URL(window.location.href);
+    const storedRoute = readSessionStorage(LAST_ROUTE_STORAGE_KEY);
+    const threadQuery = readThreadQueryConversationId(currentUrl);
+    const legacyInitialRoute = readLegacyInitialRoute(currentUrl);
+    const hasExplicitInitialRoute = currentUrl.searchParams.has(LEGACY_INITIAL_ROUTE_QUERY_KEY);
     if (currentUrl.pathname !== "/" && currentUrl.pathname !== "/index.html") {
       return;
     }
-
-    const storedRoute = readSessionStorage(LAST_ROUTE_STORAGE_KEY);
+    if (threadQuery || legacyInitialRoute || hasExplicitInitialRoute) {
+      return;
+    }
     if (!storedRoute) {
       return;
     }

--- a/src/lib/request-id.ts
+++ b/src/lib/request-id.ts
@@ -15,7 +15,7 @@ export function rewriteRequestIdsForHost(sessionId: string, message: unknown): u
   }
 
   if (
-    message.type === "mcp-request" &&
+    (message.type === "mcp-request" || message.type === "thread-prewarm-start") &&
     isJsonRecord(message.request) &&
     typeof message.request.id === "string"
   ) {
@@ -29,7 +29,7 @@ export function rewriteRequestIdsForHost(sessionId: string, message: unknown): u
   }
 
   if (
-    message.type === "mcp-request" &&
+    (message.type === "mcp-request" || message.type === "thread-prewarm-start") &&
     isJsonRecord(message.message) &&
     typeof message.message.id === "string"
   ) {

--- a/test/app-server-bridge-workers.test.ts
+++ b/test/app-server-bridge-workers.test.ts
@@ -10,6 +10,7 @@ import {
   FakeGitWorkerBridge,
   getFetchResponse,
   getFetchJsonBody,
+  getMcpResponse,
   waitForCondition,
 } from "./support/app-server-bridge-test-kit.js";
 
@@ -353,6 +354,63 @@ describeAppServerBridge(({ children }) => {
     expect(forwarded).toContain('"model":"gpt-5.4"');
     expect(forwarded).not.toContain('"config"');
     expect(forwarded).not.toContain('"modelProvider"');
+
+    await bridge.close();
+  });
+
+  it("forwards thread prewarm start requests and resolves their responses", async () => {
+    const bridge = await createBridge(children);
+    const child = children.at(0);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "thread-prewarm-start",
+      request: {
+        id: "prewarm-1",
+        method: "thread/start",
+        params: {
+          cwd: TEST_WORKSPACE_ROOT,
+          modelProvider: "codex_vscode_copilot",
+          config: {
+            analytics: "",
+            model: "gpt-5.4",
+          },
+        },
+      },
+    });
+
+    const forwarded = child?.writes ?? "";
+    expect(forwarded).toContain('"id":"prewarm-1"');
+    expect(forwarded).toContain('"method":"thread/start"');
+    expect(forwarded).toContain(`"cwd":"${TEST_WORKSPACE_ROOT}"`);
+    expect(forwarded).toContain('"model":"gpt-5.4"');
+    expect(forwarded).not.toContain('"config"');
+    expect(forwarded).not.toContain('"modelProvider"');
+
+    child?.stdout.write(
+      `${JSON.stringify({
+        id: "prewarm-1",
+        result: {
+          threadId: "thr_prewarm",
+        },
+      })}\n`,
+    );
+
+    await waitForCondition(() => Boolean(getMcpResponse(emittedMessages, "prewarm-1")));
+
+    expect(getMcpResponse(emittedMessages, "prewarm-1")).toEqual({
+      type: "mcp-response",
+      hostId: "local",
+      message: {
+        id: "prewarm-1",
+        result: {
+          threadId: "thr_prewarm",
+        },
+      },
+    });
 
     await bridge.close();
   });

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -548,6 +548,7 @@ function createBootstrapHarness(
   options: {
     href?: string;
     localStorageEntries?: Record<string, string>;
+    sessionStorageEntries?: Record<string, string>;
     mobile?: boolean;
   } = {},
 ) {
@@ -555,7 +556,9 @@ function createBootstrapHarness(
   const localStorageEntries = new Map<string, string>(
     Object.entries(options.localStorageEntries ?? {}),
   );
-  const sessionStorageEntries = new Map<string, string>();
+  const sessionStorageEntries = new Map<string, string>(
+    Object.entries(options.sessionStorageEntries ?? {}),
+  );
   const serviceWorkerRegistrations: Array<{
     scriptUrl: string;
     options?: { scope?: string; updateViaCache?: "all" | "imports" | "none" };
@@ -1559,6 +1562,32 @@ describe("renderBootstrapScript", () => {
     windowObject.history.pushState(null, "", "/local/thread-2?view=diff&token=secret#panel");
 
     expect(storage.get("__pocodex_last_route")).toBe("/local/thread-2?view=diff#panel");
+  });
+
+  it("preserves an explicit thread query when restoring the stored route", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      href: "http://127.0.0.1:8787/?token=secret&thread=thr_123",
+      sessionStorageEntries: {
+        __pocodex_last_route: "/",
+      },
+    });
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+
+    const currentUrl = new URL(harness.windowObject.location.href);
+    expect(currentUrl.searchParams.get("token")).toBe("secret");
+    expect(currentUrl.searchParams.get("thread")).toBe("thr_123");
   });
 
   it("closes the mobile sidebar after clicking thread and new-thread navigation in the sidebar", () => {
@@ -3240,37 +3269,51 @@ describe("renderBootstrapScript", () => {
     });
   });
 
-  it("clears the thread query param when clicking a new-thread control", async () => {
-    const script = renderBootstrapScript({
-      sentryOptions: {
-        buildFlavor: "stable",
-        appVersion: "1",
-        buildNumber: "123",
-        codexAppSessionId: "session-id",
-      },
-      stylesheetHref: "/pocodex.css",
-    });
+  it.each([
+    { ariaLabel: null, text: "New thread" },
+    { ariaLabel: null, text: "New chat" },
+    { ariaLabel: null, text: "New chat Ctrl+N" },
+    { ariaLabel: "Start new thread in pocodex", text: "" },
+    { ariaLabel: "Start new chat in pocodex", text: "" },
+  ])(
+    "clears the thread query param when clicking a new conversation control %#",
+    async (control) => {
+      const script = renderBootstrapScript({
+        sentryOptions: {
+          buildFlavor: "stable",
+          appVersion: "1",
+          buildNumber: "123",
+          codexAppSessionId: "session-id",
+        },
+        stylesheetHref: "/pocodex.css",
+      });
 
-    const harness = createBootstrapHarness({
-      href: "http://127.0.0.1:8787/?token=secret&thread=thr_123",
-    });
-    const nav = harness.document.createElement("nav");
-    nav.setAttribute("role", "navigation");
-    const newThreadButton = harness.document.createElement("button");
-    newThreadButton.textContent = "New thread";
-    nav.appendChild(newThreadButton);
-    harness.document.body.appendChild(nav);
+      const harness = createBootstrapHarness({
+        href: "http://127.0.0.1:8787/?token=secret&thread=thr_123",
+      });
+      const nav = harness.document.createElement("nav");
+      nav.setAttribute("role", "navigation");
+      const newConversationButton = harness.document.createElement("button");
+      if (control.ariaLabel) {
+        newConversationButton.setAttribute("aria-label", control.ariaLabel);
+      }
+      newConversationButton.textContent = control.text;
+      nav.appendChild(newConversationButton);
+      harness.document.body.appendChild(nav);
 
-    harness.run(script);
-    await flushBootstrapMicrotasks();
+      harness.run(script);
+      await flushBootstrapMicrotasks();
 
-    harness.document.dispatchEvent(new TestMouseEvent("click", { target: newThreadButton }));
-    drainTestTimers(harness.timers);
+      harness.document.dispatchEvent(
+        new TestMouseEvent("click", { target: newConversationButton }),
+      );
+      drainTestTimers(harness.timers);
 
-    const currentUrl = new URL(harness.windowObject.location.href);
-    expect(currentUrl.searchParams.get("token")).toBe("secret");
-    expect(currentUrl.searchParams.get("thread")).toBeNull();
-  });
+      const currentUrl = new URL(harness.windowObject.location.href);
+      expect(currentUrl.searchParams.get("token")).toBe("secret");
+      expect(currentUrl.searchParams.get("thread")).toBeNull();
+    },
+  );
 
   it("dispatches a single local-thread restore sequence after ready for a thread query param", async () => {
     const script = renderBootstrapScript({

--- a/test/request-id.test.ts
+++ b/test/request-id.test.ts
@@ -24,6 +24,17 @@ describe("request-id routing", () => {
     expect(rewritten.request.id).toBe("pocodex:session-a:mcp-1");
   });
 
+  it("prefixes thread prewarm request IDs for the host renderer", () => {
+    const rewritten = rewriteRequestIdsForHost("session-a", {
+      type: "thread-prewarm-start",
+      request: {
+        id: "prewarm-1",
+      },
+    }) as { request: { id: string } };
+
+    expect(rewritten.request.id).toBe("pocodex:session-a:prewarm-1");
+  });
+
   it("strips prefixed host response IDs and routes them to the right session", () => {
     const routed = routeHostMessage({
       type: "fetch-response",


### PR DESCRIPTION
## Summary

This restores responsive `New chat` startup in Pocodex by recognizing the current Codex bundle's new-conversation triggers and routing `thread-prewarm-start` responses back to the correct browser session instead of letting prewarm fall through to the timeout path.

## What changed

- update the bootstrap new-conversation trigger detection to handle both older `New thread` labels and newer `New chat` labels, including shortcut-suffixed sidebar text
- preserve explicit `?thread=` and initial-route deep links instead of overwriting them with the stored `/` route during bootstrap restore
- forward `thread-prewarm-start` through the app-server bridge on the same `thread/start` sanitization path used for normal MCP requests
- prefix prewarm request ids in the host routing layer so returning `mcp-response` messages resolve back to the originating browser session
- add focused regression coverage in `test/bootstrap-script.test.ts`, `test/app-server-bridge-workers.test.ts`, and `test/request-id.test.ts`

## Root cause

- newer Codex bundles initiate `New chat` startup with a `thread-prewarm-start` request before the real thread handoff
- Pocodex still relied on older `New thread` trigger text in parts of the bootstrap flow and only rewrote host request ids for `mcp-request`
- that let stale thread restore state survive newer `New chat` controls and caused the prewarm response to be dropped instead of routed back to the browser
- once the response was dropped, the bundle waited for its prewarm timeout and only then issued a second real `thread/start`, which produced the long startup stall

## Impact

- `New chat` no longer waits for the prewarm timeout before the real thread handoff can complete
- explicit thread deep links and initial-route launches are preserved instead of being replaced by the stored root route
- focused regression coverage now protects both the new-conversation trigger detection and the prewarm request-routing contract

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run test/request-id.test.ts test/app-server-bridge-workers.test.ts test/bootstrap-script.test.ts`
- live local verification on `http://127.0.0.1:8796/` showed about `10.2s` on a cold run and about `1.0s` on the immediate retry instead of the prior ~`30s` stall
