### PR TITLE
Fix: restore projectless new chat startup

### DIFF
--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -1796,6 +1796,11 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
             labels: Object.fromEntries(this.workspaceRootLabels),
           },
         };
+      case "projectless-thread-cwd":
+        return {
+          status: 200,
+          body: this.readProjectlessThreadCwd(),
+        };
       case "add-workspace-root-option":
         return {
           status: 200,
@@ -2261,6 +2266,25 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       canMerge,
       ciStatus: deriveGhCiStatus(prInfo.statusCheckRollup),
       url: prInfo.url,
+    };
+  }
+
+  private readProjectlessThreadCwd(): {
+    cwd: string;
+    outputDirectory: string;
+    workspaceRoot: string;
+  } {
+    const cwd = homedir();
+    const workspaceRoot =
+      (this.activeWorkspaceRoot && existsSync(this.activeWorkspaceRoot)
+        ? this.activeWorkspaceRoot
+        : null) ??
+      Array.from(this.workspaceRoots).find((root) => existsSync(root)) ??
+      cwd;
+    return {
+      cwd,
+      outputDirectory: cwd,
+      workspaceRoot,
     };
   }
 

--- a/test/app-server-bridge-basic.test.ts
+++ b/test/app-server-bridge-basic.test.ts
@@ -16,6 +16,7 @@ import {
   waitForCondition,
   toSvgDataUrl,
   isBridgeMessage,
+  writeWorkspaceRootRegistry,
 } from "./support/app-server-bridge-test-kit.js";
 
 describeAppServerBridge(({ children }) => {
@@ -481,6 +482,45 @@ describeAppServerBridge(({ children }) => {
     await bridge.close();
   });
 
+  it("resolves the projectless thread cwd using home and the active workspace root", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-projectless-thread-cwd-"));
+    tempDirs.push(tempDirectory);
+    const workspaceRootRegistryPath = await writeWorkspaceRootRegistry(tempDirectory, {
+      roots: [TEST_WORKSPACE_ROOT],
+      activeRoot: TEST_WORKSPACE_ROOT,
+    });
+    const bridge = await createBridge(children, {
+      workspaceRootRegistryPath,
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-projectless-thread-cwd",
+      method: "POST",
+      url: "vscode://codex/projectless-thread-cwd",
+      body: JSON.stringify({
+        params: {
+          prompt: "Create a scratch file",
+        },
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-projectless-thread-cwd")),
+    );
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-projectless-thread-cwd")).toEqual({
+      cwd: homedir(),
+      outputDirectory: homedir(),
+      workspaceRoot: TEST_WORKSPACE_ROOT,
+    });
+
+    await bridge.close();
+  });
   it("creates on attach, ignores early resize, and rebinds terminal sessions by conversation", async () => {
     process.env.SHELL = "/bin/zsh";
     const bridge = await createBridge(children);


### PR DESCRIPTION
## Summary

This restores projectless `New chat` startup in Pocodex by implementing the missing `vscode://codex/projectless-thread-cwd` bridge contract the current Codex bundle now calls before creating a non-project local thread.

## What changed

- add an app-server bridge handler for `vscode://codex/projectless-thread-cwd`
- return the newer bundle payload shape with `cwd`, `outputDirectory`, and `workspaceRoot`
- resolve projectless threads to `homedir()` for `cwd` and `outputDirectory` while preserving the active existing workspace root for the browser pane
- add focused regression coverage in `test/app-server-bridge-basic.test.ts` for the projectless thread cwd fetch contract

## Root cause

- the current Codex bundle now requests `vscode://codex/projectless-thread-cwd` when starting a projectless local chat
- Pocodex did not implement that host fetch route, so the request fell through to the generic unsupported-route `501` path
- once that bridge contract failed, projectless `New chat` startup surfaced `Unsupported Codex host fetch URL: vscode://codex/projectless-thread-cwd` instead of resolving the thread cwd

## Impact

- projectless local chats can resolve their startup cwd again instead of failing on the missing host route
- the current bundle receives the `cwd`, `outputDirectory`, and `workspaceRoot` payload shape it expects
- focused regression coverage now protects this projectless host fetch contract from falling back to unsupported-route behavior again

## Validation

- `pnpm run check:commit`
- `pnpm exec vitest run test/app-server-bridge-basic.test.ts`
- `pnpm dev --listen 127.0.0.1:8891`
- live websocket verification against `ws://127.0.0.1:8891/session` that `vscode://codex/projectless-thread-cwd` returned `200` with `cwd=/root`, `outputDirectory=/root`, and `workspaceRoot=/root/repos/xigbclutchix/pocodex`
