### PR TITLE
fix(bootstrap): stabilize sidebar toggle

### DIFF
--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -538,8 +538,11 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
     scheduleSidebarModeReconcile(5);
     const target = event.target instanceof Element ? event.target : null;
-    if (target) {
-      armSidebarModeInteractionIfToggleTrigger(target);
+    const nextMode = target ? readSidebarToggleTarget(target) : null;
+    if (nextMode) {
+      armSidebarModeInteraction();
+      persistExpectedSidebarToggleTarget(nextMode);
+      scheduleSidebarToggleFallback(nextMode);
     }
   }
 
@@ -767,6 +770,10 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       return true;
     }
 
+    if (viewportWidth > 0 && rect.left <= 8 && rect.width >= viewportWidth - 16) {
+      return false;
+    }
+
     if (viewportWidth > 0 && rect.width > 0 && rect.width < viewportWidth - 0.5) {
       return true;
     }
@@ -958,17 +965,29 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     return true;
   }
 
-  function armSidebarModeInteractionIfToggleTrigger(target: Element): void {
+  function readSidebarToggleTarget(target: Element): SidebarMode | null {
     const nearestInteractive = target.closest('button, a, [role="button"]');
     if (!(nearestInteractive instanceof Element)) {
-      return;
+      return null;
     }
 
-    if (!isSidebarToggleTrigger(nearestInteractive)) {
-      return;
+    const ariaLabel = nearestInteractive.getAttribute("aria-label")?.trim().toLowerCase() ?? "";
+    if (ariaLabel === "hide sidebar") {
+      return "collapsed";
+    }
+    if (ariaLabel === "show sidebar") {
+      return "expanded";
     }
 
-    armSidebarModeInteraction();
+    const title = nearestInteractive.getAttribute("title")?.trim().toLowerCase() ?? "";
+    if (title === "hide sidebar") {
+      return "collapsed";
+    }
+    if (title === "show sidebar") {
+      return "expanded";
+    }
+
+    return null;
   }
 
   function armSidebarModeInteraction(): void {
@@ -1000,14 +1019,24 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     pendingSidebarModeTargetUntil = 0;
   }
 
-  function isSidebarToggleTrigger(element: Element): boolean {
-    const ariaLabel = element.getAttribute("aria-label")?.trim().toLowerCase() ?? "";
-    if (ariaLabel === "hide sidebar" || ariaLabel === "show sidebar") {
-      return true;
-    }
+  function persistExpectedSidebarToggleTarget(nextMode: SidebarMode): void {
+    hasReceivedSidebarModeSync = true;
+    hasRestoredSidebarMode = true;
+    persistSidebarMode(nextMode);
+    notePendingSidebarModeTarget(nextMode);
+  }
 
-    const title = element.getAttribute("title")?.trim().toLowerCase() ?? "";
-    return title === "hide sidebar" || title === "show sidebar";
+  function scheduleSidebarToggleFallback(nextMode: SidebarMode): void {
+    window.setTimeout(() => {
+      if (readSidebarMode() === nextMode) {
+        return;
+      }
+
+      armSidebarModeInteraction();
+      notePendingSidebarModeTarget(nextMode);
+      dispatchHostMessage({ type: "toggle-sidebar" });
+      scheduleSidebarModeReconcile(5);
+    }, 0);
   }
 
   function isSidebarToggleShortcut(event: KeyboardEvent): boolean {
@@ -3508,6 +3537,13 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
           type: "electron-window-focus-changed",
           isFocused: isDocumentVisible() && hasDocumentFocus(),
         });
+        return;
+      }
+      if (isRecord(message) && message.type === "toggle-sidebar") {
+        const nextMode = readSidebarMode() === "expanded" ? "collapsed" : "expanded";
+        armSidebarModeInteraction();
+        persistExpectedSidebarToggleTarget(nextMode);
+        dispatchHostMessage(message);
         return;
       }
       syncRestorableTerminalAttachments(message, "outgoing");

--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -127,6 +127,8 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   const LEGACY_SIDEBAR_MODE_PERSISTED_ATOM_KEY = "pocodex-sidebar-mode";
   const SIDEBAR_INTERACTION_ARM_MS = 500;
   const SIDEBAR_MODE_TOGGLE_SETTLE_MS = 350;
+  const MOBILE_SIDEBAR_MODE_TOGGLE_SETTLE_MS = 1_000;
+  const SIDEBAR_MODE_COMMAND_SETTLE_MS = 1_500;
   const HEARTBEAT_STALE_AFTER_MS = 45_000;
   const HEARTBEAT_MONITOR_INTERVAL_MS = 5_000;
   const WAKE_GRACE_PERIOD_MS = 10_000;
@@ -183,6 +185,9 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   let sidebarModeInteractionTimer: number | null = null;
   let pendingSidebarModeTarget: SidebarMode | null = null;
   let pendingSidebarModeTargetUntil = 0;
+  let sidebarToggleFallbackToken = 0;
+  let suppressNextSidebarBridgeToggle = false;
+  let suppressNextSidebarBridgeToggleTimer: number | null = null;
   let settingsShellObserver: MutationObserver | null = null;
   let workspaceRootPickerState: WorkspaceRootPickerState | null = null;
 
@@ -536,14 +541,15 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       return;
     }
 
-    scheduleSidebarModeReconcile(5);
     const target = event.target instanceof Element ? event.target : null;
     const nextMode = target ? readSidebarToggleTarget(target) : null;
     if (nextMode) {
       armSidebarModeInteraction();
       persistExpectedSidebarToggleTarget(nextMode);
       scheduleSidebarToggleFallback(nextMode);
+      return;
     }
+    scheduleSidebarModeReconcile(5);
   }
 
   function handleSidebarKeydown(event: KeyboardEvent): void {
@@ -703,6 +709,10 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       return;
     }
 
+    if (readSidebarToggleTarget(target)) {
+      return;
+    }
+
     if (target.closest('nav[role="navigation"]') || !target.closest(".main-surface")) {
       return;
     }
@@ -718,7 +728,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     window.setTimeout(() => {
       if (isMobileSidebarViewport() && isMobileSidebarOpen()) {
         armSidebarModeInteraction();
-        dispatchHostMessage({ type: "toggle-sidebar" });
+        dispatchSidebarToggleCommand({ suppressBridgeEcho: true });
         scheduleSidebarModeReconcile(5);
       }
     }, 0);
@@ -865,7 +875,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
           return;
         }
         notePendingSidebarModeTarget(desiredMode);
-        dispatchHostMessage({ type: "toggle-sidebar" });
+        dispatchSidebarToggleCommand({ suppressBridgeEcho: true });
         if (retriesRemaining > 0) {
           scheduleSidebarModeReconcile(retriesRemaining - 1, 50);
         }
@@ -881,7 +891,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
     if (!isSidebarModeInteractionArmed) {
       notePendingSidebarModeTarget(desiredMode);
-      dispatchHostMessage({ type: "toggle-sidebar" });
+      dispatchSidebarToggleCommand({ suppressBridgeEcho: true });
       if (retriesRemaining > 0) {
         scheduleSidebarModeReconcile(retriesRemaining - 1, 50);
       }
@@ -892,6 +902,10 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   }
 
   function readSidebarMode(): SidebarMode | null {
+    if (isDesktopSidebarVisible()) {
+      return "expanded";
+    }
+
     if (isMobileSidebarViewport()) {
       return isMobileSidebarOpen() ? "expanded" : "collapsed";
     }
@@ -921,12 +935,32 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       return "expanded";
     }
 
-    const viewportWidth = typeof window.innerWidth === "number" ? window.innerWidth : 0;
-    if (viewportWidth > 0 && rect.width > 0 && rect.width < viewportWidth - 0.5) {
-      return "expanded";
-    }
-
     return "collapsed";
+  }
+
+  function isDesktopSidebarVisible(): boolean {
+    const sidebars = document.querySelectorAll('[role="complementary"]');
+    const viewportWidth = typeof window.innerWidth === "number" ? window.innerWidth : 0;
+    for (let index = 0; index < sidebars.length; index += 1) {
+      const sidebar = sidebars.item(index);
+      if (
+        !(sidebar instanceof Element) ||
+        !sidebar.querySelector('nav[aria-label="Automation folders"]') ||
+        typeof sidebar.getBoundingClientRect !== "function"
+      ) {
+        continue;
+      }
+
+      const rect = sidebar.getBoundingClientRect();
+      if (
+        rect.width > 0.5 &&
+        rect.right > 0.5 &&
+        (viewportWidth <= 0 || rect.left < viewportWidth - 0.5)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   function readSidebarModeValue(value: unknown): SidebarMode | null {
@@ -1009,14 +1043,34 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     }
   }
 
-  function notePendingSidebarModeTarget(mode: SidebarMode): void {
+  function notePendingSidebarModeTarget(
+    mode: SidebarMode,
+    settleMs = getSidebarModeToggleSettleMs(),
+  ): void {
     pendingSidebarModeTarget = mode;
-    pendingSidebarModeTargetUntil = Date.now() + SIDEBAR_MODE_TOGGLE_SETTLE_MS;
+    pendingSidebarModeTargetUntil = Date.now() + settleMs;
   }
 
   function clearPendingSidebarModeTarget(): void {
     pendingSidebarModeTarget = null;
     pendingSidebarModeTargetUntil = 0;
+  }
+
+  function clearSuppressedSidebarBridgeToggle(): void {
+    suppressNextSidebarBridgeToggle = false;
+    if (suppressNextSidebarBridgeToggleTimer !== null) {
+      window.clearTimeout(suppressNextSidebarBridgeToggleTimer);
+      suppressNextSidebarBridgeToggleTimer = null;
+    }
+  }
+
+  function armSidebarBridgeEchoSuppression(): void {
+    clearSuppressedSidebarBridgeToggle();
+    suppressNextSidebarBridgeToggle = true;
+    suppressNextSidebarBridgeToggleTimer = window.setTimeout(() => {
+      suppressNextSidebarBridgeToggle = false;
+      suppressNextSidebarBridgeToggleTimer = null;
+    }, 0);
   }
 
   function persistExpectedSidebarToggleTarget(nextMode: SidebarMode): void {
@@ -1027,16 +1081,44 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   }
 
   function scheduleSidebarToggleFallback(nextMode: SidebarMode): void {
+    const fallbackToken = ++sidebarToggleFallbackToken;
+    const settleMs = getSidebarModeToggleSettleMs();
     window.setTimeout(() => {
-      if (readSidebarMode() === nextMode) {
+      if (fallbackToken !== sidebarToggleFallbackToken) {
         return;
       }
 
-      armSidebarModeInteraction();
-      notePendingSidebarModeTarget(nextMode);
-      dispatchHostMessage({ type: "toggle-sidebar" });
-      scheduleSidebarModeReconcile(5);
-    }, 0);
+      if (readSidebarMode() !== nextMode && !hasSidebarToggleControlForMode(nextMode)) {
+        dispatchSidebarToggleFallback(nextMode, fallbackToken);
+        return;
+      }
+
+      window.setTimeout(() => {
+        if (fallbackToken !== sidebarToggleFallbackToken) {
+          return;
+        }
+
+        if (readSidebarMode() !== nextMode && !hasSidebarToggleControlForMode(nextMode)) {
+          dispatchSidebarToggleFallback(nextMode, fallbackToken);
+        }
+      }, settleMs);
+    }, settleMs);
+  }
+
+  function getSidebarModeToggleSettleMs(): number {
+    if (isMobileSidebarViewport() && !isDesktopSidebarVisible()) {
+      return MOBILE_SIDEBAR_MODE_TOGGLE_SETTLE_MS;
+    }
+    return SIDEBAR_MODE_TOGGLE_SETTLE_MS;
+  }
+
+  function dispatchSidebarToggleFallback(nextMode: SidebarMode, fallbackToken: number): void {
+    if (fallbackToken !== sidebarToggleFallbackToken) {
+      return;
+    }
+
+    notePendingSidebarModeTarget(nextMode, SIDEBAR_MODE_COMMAND_SETTLE_MS);
+    dispatchSidebarToggleCommand({ suppressBridgeEcho: true });
   }
 
   function isSidebarToggleShortcut(event: KeyboardEvent): boolean {
@@ -1055,6 +1137,51 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     sidebarModeFromHost = mode;
     const storage = getSidebarModeStorage();
     storage?.setItem(getSidebarModePersistedAtomKey(), mode);
+  }
+
+  function hasSidebarToggleControlForMode(mode: SidebarMode): boolean {
+    const label = mode === "collapsed" ? "show sidebar" : "hide sidebar";
+    const buttons = document.querySelectorAll(
+      'button[aria-label="Hide sidebar"], button[aria-label="Show sidebar"], button[title="Hide sidebar"], button[title="Show sidebar"]',
+    );
+    for (let index = 0; index < buttons.length; index += 1) {
+      const button = buttons.item(index);
+      const ariaLabel = button.getAttribute("aria-label")?.trim().toLowerCase();
+      const title = button.getAttribute("title")?.trim().toLowerCase();
+      if ((ariaLabel === label || title === label) && isSidebarToggleControlVisible(button)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function isSidebarToggleControlVisible(element: Element): boolean {
+    let current: Element | null = element;
+    while (current) {
+      const style = (current as HTMLElement).style;
+      if (
+        (current as HTMLElement).hidden ||
+        current.getAttribute("aria-hidden") === "true" ||
+        style?.display === "none" ||
+        style?.visibility === "hidden" ||
+        style?.visibility === "collapse"
+      ) {
+        return false;
+      }
+      current = current.parentElement;
+    }
+
+    if (typeof element.getBoundingClientRect !== "function") {
+      return true;
+    }
+
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 0.5) {
+      return false;
+    }
+
+    const viewportWidth = typeof window.innerWidth === "number" ? window.innerWidth : 0;
+    return viewportWidth <= 0 || (rect.right > 0.5 && rect.left < viewportWidth - 0.5);
   }
 
   function isPrimaryUnmodifiedClick(event: MouseEvent): boolean {
@@ -2308,6 +2435,13 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
     window.dispatchEvent(new MessageEvent("message", { data: message }));
   }
 
+  function dispatchSidebarToggleCommand(options: { suppressBridgeEcho?: boolean } = {}): void {
+    if (options.suppressBridgeEcho) {
+      armSidebarBridgeEchoSuppression();
+    }
+    dispatchHostMessage({ type: "toggle-sidebar" });
+  }
+
   function syncSidebarModeWithBridgeMessage(message: unknown): void {
     if (!isRecord(message) || typeof message.type !== "string") {
       return;
@@ -3540,10 +3674,15 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
         return;
       }
       if (isRecord(message) && message.type === "toggle-sidebar") {
+        if (suppressNextSidebarBridgeToggle) {
+          clearSuppressedSidebarBridgeToggle();
+          return;
+        }
         const nextMode = readSidebarMode() === "expanded" ? "collapsed" : "expanded";
+        sidebarToggleFallbackToken += 1;
         armSidebarModeInteraction();
         persistExpectedSidebarToggleTarget(nextMode);
-        dispatchHostMessage(message);
+        dispatchSidebarToggleCommand();
         return;
       }
       syncRestorableTerminalAttachments(message, "outgoing");

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -2678,6 +2678,257 @@ describe("renderBootstrapScript", () => {
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
   });
 
+  it("falls back when the desktop toolbar toggle only collapses transiently", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 300, width: 980 });
+    const toggleButton = harness.document.createElement("button");
+    toggleButton.setAttribute("aria-label", "Hide sidebar");
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(toggleButton);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: toggleButton }));
+    contentPane.setBoundingClientRect({ left: 0, width: 1280 });
+    drainTestTimers(harness.timers, 2);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+
+    contentPane.setBoundingClientRect({ left: 300, width: 980 });
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("relays the desktop toolbar app command without a fallback double-toggle", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 300, width: 980 });
+    const toggleButton = harness.document.createElement("button");
+    toggleButton.setAttribute("aria-label", "Hide sidebar");
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(toggleButton);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: toggleButton }));
+    await harness.getElectronBridge().sendMessageFromView({
+      type: "toggle-sidebar",
+    });
+    contentPane.setBoundingClientRect({ left: 0, width: 1280 });
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("derives delayed sidebar bridge toggles from the current mode", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 300, width: 980 });
+    const toggleButton = harness.document.createElement("button");
+    toggleButton.setAttribute("aria-label", "Hide sidebar");
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(toggleButton);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: toggleButton }));
+    contentPane.setBoundingClientRect({ left: 0, width: 1280 });
+    drainTestTimers(harness.timers, 2);
+
+    await harness.getElectronBridge().sendMessageFromView({
+      type: "toggle-sidebar",
+    });
+
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
+  });
+
+  it("falls back for a visible desktop sidebar when the viewport query also matches mobile", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const sidebar = harness.document.createElement("div");
+    sidebar.setAttribute("role", "complementary");
+    sidebar.setBoundingClientRect({ left: 0, width: 300 });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("aria-label", "Automation folders");
+    sidebar.appendChild(navigation);
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 300, width: 980 });
+    const toggleButton = harness.document.createElement("button");
+    toggleButton.setAttribute("aria-label", "Hide sidebar");
+    harness.document.body.appendChild(sidebar);
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(toggleButton);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: toggleButton }));
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("keeps a visible desktop sidebar expanded when the viewport query also matches mobile", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const sidebar = harness.document.createElement("div");
+    sidebar.setAttribute("role", "complementary");
+    sidebar.setBoundingClientRect({ left: 0, width: 300 });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("aria-label", "Automation folders");
+    sidebar.appendChild(navigation);
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 0, width: 390 });
+    harness.document.body.appendChild(sidebar);
+    harness.document.body.appendChild(contentPane);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
+  });
+
+  it("ignores hidden sidebar controls when deciding whether to fall back", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 300, width: 980 });
+    const visibleToggleButton = harness.document.createElement("button");
+    visibleToggleButton.setAttribute("aria-label", "Hide sidebar");
+    const hiddenToggleButton = harness.document.createElement("button");
+    hiddenToggleButton.hidden = true;
+    hiddenToggleButton.setAttribute("aria-label", "Show sidebar");
+    hiddenToggleButton.setBoundingClientRect({ left: 0, width: 120 });
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(visibleToggleButton);
+    harness.document.body.appendChild(hiddenToggleButton);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: visibleToggleButton }));
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
   it("keeps the desktop sidebar expanded when no host mode has been stored", async () => {
     const script = renderBootstrapScript({
       sentryOptions: {
@@ -2710,6 +2961,73 @@ describe("renderBootstrapScript", () => {
     drainTestTimers(harness.timers);
 
     expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+  });
+
+  it("does not treat narrow desktop content as expanded when it starts at the viewport edge", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "collapsed",
+      },
+    });
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 0, width: 760 });
+    harness.document.body.appendChild(contentPane);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("treats the visible desktop sidebar landmark as expanded", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const sidebar = harness.document.createElement("div");
+    sidebar.setAttribute("role", "complementary");
+    sidebar.setBoundingClientRect({ left: 0, width: 300 });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("aria-label", "Automation folders");
+    sidebar.appendChild(navigation);
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    contentPane.setBoundingClientRect({ left: 0, width: 760 });
+    harness.document.body.appendChild(sidebar);
+    harness.document.body.appendChild(contentPane);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
   });
 
   it("reapplies the stored desktop sidebar mode when the shell resets after restore", async () => {
@@ -2826,9 +3144,9 @@ describe("renderBootstrapScript", () => {
     contentPane.setAttribute("class", "main-surface");
     const toggleButton = harness.document.createElement("button");
     toggleButton.setAttribute("aria-label", "Show sidebar");
+    contentPane.appendChild(toggleButton);
     harness.document.body.appendChild(navigation);
     harness.document.body.appendChild(contentPane);
-    harness.document.body.appendChild(toggleButton);
     setMobileSidebarOpenState(contentPane, navigation);
 
     harness.run(script);
@@ -2853,7 +3171,7 @@ describe("renderBootstrapScript", () => {
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
   });
 
-  it("falls back to host sidebar toggle when toolbar click leaves mode unchanged", async () => {
+  it("does not double-toggle while a mobile toolbar close is still animating", async () => {
     const script = renderBootstrapScript({
       sentryOptions: {
         buildFlavor: "stable",
@@ -2876,9 +3194,9 @@ describe("renderBootstrapScript", () => {
     const toggleButton = harness.document.createElement("button");
     toggleButton.setAttribute("aria-label", "Sidebar");
     toggleButton.setAttribute("title", "Hide sidebar");
+    contentPane.appendChild(toggleButton);
     harness.document.body.appendChild(navigation);
     harness.document.body.appendChild(contentPane);
-    harness.document.body.appendChild(toggleButton);
     setMobileSidebarOpenState(contentPane, navigation);
 
     harness.run(script);
@@ -2888,6 +3206,9 @@ describe("renderBootstrapScript", () => {
     harness.dispatchedMessages.length = 0;
 
     harness.document.dispatchEvent(new TestMouseEvent("click", { target: toggleButton }));
+    await harness.getElectronBridge().sendMessageFromView({
+      type: "toggle-sidebar",
+    });
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
     drainTestTimers(harness.timers);
 
@@ -2992,6 +3313,64 @@ describe("renderBootstrapScript", () => {
     expect(toggleMessages).toHaveLength(1);
 
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("expires suppressed sidebar bridge echoes after automatic mobile closes", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    const contentChild = harness.document.createElement("div");
+    contentPane.appendChild(contentChild);
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: contentChild }));
+    for (let index = 0; index < 5; index += 1) {
+      if (
+        harness.dispatchedMessages.some(
+          (message) => JSON.stringify(message) === JSON.stringify({ type: "toggle-sidebar" }),
+        )
+      ) {
+        break;
+      }
+      drainTestTimers(harness.timers, 1);
+    }
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+
+    setMobileSidebarClosedState(contentPane, navigation);
+    drainTestTimers(harness.timers);
+    await harness.getElectronBridge().sendMessageFromView({
+      type: "toggle-sidebar",
+    });
+
+    const toggleMessages = harness.dispatchedMessages.filter(
+      (message) => JSON.stringify(message) === JSON.stringify({ type: "toggle-sidebar" }),
+    );
+    expect(toggleMessages).toHaveLength(2);
   });
 
   it("does not treat the mobile sidebar as open when the content pane has the collapsed class", async () => {
@@ -3188,7 +3567,7 @@ describe("renderBootstrapScript", () => {
     expect(toggleMessages).toHaveLength(1);
   });
 
-  it("handles sidebar toggle host commands locally", async () => {
+  it("relays sidebar toggle bridge messages through the app command", async () => {
     const script = renderBootstrapScript({
       sentryOptions: {
         buildFlavor: "stable",
@@ -3222,11 +3601,15 @@ describe("renderBootstrapScript", () => {
     await harness.getElectronBridge().sendMessageFromView({
       type: "toggle-sidebar",
     });
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+
     setMobileSidebarClosedState(contentPane, navigation);
     harness.windowObject.dispatchEvent({ type: "resize" });
     drainTestTimers(harness.timers);
 
-    expect(harness.dispatchedMessages).toContainEqual({ type: "toggle-sidebar" });
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
     expect(harness.getSentEnvelopes()).toHaveLength(sentBefore);
   });

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -2853,6 +2853,48 @@ describe("renderBootstrapScript", () => {
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
   });
 
+  it("falls back to host sidebar toggle when toolbar click leaves mode unchanged", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    const toggleButton = harness.document.createElement("button");
+    toggleButton.setAttribute("aria-label", "Sidebar");
+    toggleButton.setAttribute("title", "Hide sidebar");
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(toggleButton);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: toggleButton }));
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toEqual([{ type: "toggle-sidebar" }]);
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
   it("defaults the mobile sidebar to expanded when no host mode has been stored", async () => {
     const script = renderBootstrapScript({
       sentryOptions: {
@@ -2993,6 +3035,48 @@ describe("renderBootstrapScript", () => {
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
   });
 
+  it("does not treat full-width mobile content as open when navigation remains measurable", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "collapsed",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    const contentChild = harness.document.createElement("div");
+    contentPane.appendChild(contentChild);
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    setMobileSidebarClosedState(contentPane, navigation);
+    navigation.setBoundingClientRect({ left: 0, width: 240 });
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: contentChild }));
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
   it("reapplies the stored mobile sidebar mode when the shell resets after restore", async () => {
     const script = renderBootstrapScript({
       sentryOptions: {
@@ -3102,6 +3186,49 @@ describe("renderBootstrapScript", () => {
       (message) => JSON.stringify(message) === JSON.stringify({ type: "toggle-sidebar" }),
     );
     expect(toggleMessages).toHaveLength(1);
+  });
+
+  it("handles sidebar toggle host commands locally", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    const sentBefore = harness.getSentEnvelopes().length;
+
+    await harness.getElectronBridge().sendMessageFromView({
+      type: "toggle-sidebar",
+    });
+    setMobileSidebarClosedState(contentPane, navigation);
+    harness.windowObject.dispatchEvent({ type: "resize" });
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+    expect(harness.getSentEnvelopes()).toHaveLength(sentBefore);
   });
 
   it("stores the active local thread in the thread query param", async () => {


### PR DESCRIPTION
Fixes sidebar toggle behaviour across desktop and mobile.

- Prevents mobile content-pane click handling from double-processing sidebar toolbar clicks
- Adds fallback handling when a sidebar toggle animation leaves the mode unchanged
- Keeps desktop/mobile sidebar mode detection from fighting responsive layouts
- Avoids suppressing the app’s own toolbar toggle bridge command
- Adds regression coverage for desktop, mobile, hidden controls, bridge echoes, and delayed toggle messages
