### PR TITLE
fix: harden access safety + UI + workspace sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pocodex
 
 Pocodex prints a local URL and, when applicable, an "Open" URL. Open the printed URL in your browser.
 
-Pocodex now publishes a web manifest and service worker, so on supported browsers you can install it as a standalone app. If you are using a tokenized URL, open that URL once in the browser you plan to install from so the token is stored for later standalone launches.
+Pocodex now publishes a web manifest and service worker, so on supported browsers you can install it as a standalone app. If you are using a tokenized URL, open that URL in the browser you plan to install from. Tokens are stored for the current browser session only, so a standalone/PWA launch may need the current printed URL again after the browser session is cleared.
 
 ## Requirements
 
@@ -60,7 +60,9 @@ pocodex [--token <secret>] [--app <path>] [--listen 127.0.0.1:8787] [--dev]
 - `--listen` host and port to bind, for example `127.0.0.1:8787` or `0.0.0.0:8787`
 - `--dev` watches `src/pocodex.css` and pushes live CSS reload events to the connected browser
 
-If you expose Pocodex beyond loopback, use a long random token. When configured, the token gates `/session`, and the browser bootstrap stores it in `sessionStorage` so reconnects can work without re-entering it.
+If you expose Pocodex beyond loopback, use only the printed tokenized URL on a trusted network. The token gates `/session`, `/ipc-request`, and host bridge access, and the browser bootstrap stores it in `sessionStorage` for reconnects during the current browser session.
+
+By default, Pocodex uses the same Codex home/state as the desktop app. To keep a separate Pocodex environment, run it with a separate `CODEX_HOME`.
 
 When `--app` is omitted, Pocodex auto-detects `/Applications/Codex.app` on macOS or the newest `OpenAI.Codex_*` Windows Store install when running inside WSL.
 
@@ -96,7 +98,7 @@ Codex's webview expects to live inside Electron with a pile of host APIs behind 
 - terminal sessions are backed by local PTYs via `node-pty`
 - git integration is bridged through the desktop git worker extracted from the Codex bundle
 - browser `vscode://codex/ipc-request` traffic is translated onto Pocodex's host IPC endpoint
-- workspace roots, persisted atoms, and related desktop state are mirrored on the host side
+- workspace roots, pinned threads, persisted atoms, and related desktop sidebar state are mirrored on the host side
 - unsupported native features are blocked or stubbed where needed
 
 The shim behavior was derived by treating the shipped and minified `Codex.app` code as the implementation oracle.
@@ -105,7 +107,7 @@ The shim behavior was derived by treating the shipped and minified `Codex.app` c
 
 Pocodex creates an HTTP server on the host machine and serves the patched webview from there. The browser loads the UI over HTTP, uses `/ipc-request` for host-style requests, and opens a live WebSocket session on `/session` for bridge traffic and worker messages.
 
-An optional token can gate the browser session. Pocodex supports multiple concurrent browser sessions that share the same backend state.
+A session token gates the browser session. Pocodex supports multiple concurrent browser sessions that share the same backend state.
 
 ## Current Limitations
 
@@ -114,7 +116,7 @@ An optional token can gate the browser session. Pocodex supports multiple concur
 - Streaming fetch is not implemented
 - Personal ChatGPT cloud fetches under `/wham/*` are proxied through managed local auth, but some workspace, billing, and subscription endpoints still return stubs or placeholder data
 - This relies on internal Codex bundle structure and host protocols, so Codex app updates may break assumptions
-- Security is intentionally light; this is suitable for local use and trusted LANs, not public exposure
+- Pocodex is suitable for local use and trusted LANs with the printed tokenized URL. Do not expose it directly to the public internet; use Tailscale, WireGuard, Cloudflare Access, or another private access layer for away-from-home use.
 
 ## Contributing
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { watch } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, dirname } from "node:path";
@@ -173,7 +173,7 @@ async function parseServeCommand(argv: string[]): Promise<ServeCommandOptions> {
 
   const appPath = readFlag(argv, "--app") ?? (await resolveDefaultCodexAppPath());
   const listen = readFlag(argv, "--listen") ?? DEFAULT_LISTEN;
-  const token = readFlag(argv, "--token") ?? "";
+  const token = readFlag(argv, "--token") ?? randomBytes(32).toString("hex");
   const devMode = hasFlag(argv, "--dev");
 
   const parsedListenAddress = parseListenAddress(listen);

--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -2,12 +2,18 @@ import { randomUUID } from "node:crypto";
 import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { arch, homedir, platform } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { createInterface } from "node:readline";
 
 import { ensureCodexCliBinary } from "./codex-bundle.js";
+import {
+  loadCodexDesktopState,
+  saveCodexDesktopPinnedThreadIds,
+  type CodexDesktopProject,
+  type LoadedCodexDesktopState,
+} from "./codex-desktop-projects.js";
 import { deriveCodexHomePath } from "./codex-home.js";
 import {
   DefaultCodexDesktopGitWorkerBridge,
@@ -291,12 +297,14 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
   private readonly workspaceRoots = new Set<string>();
   private readonly workspaceRootLabels = new Map<string, string>();
   private readonly codexHomePath: string;
+  private desktopGlobalStatePath: string;
   private persistedAtomRegistryPath: string;
   private workspaceRootRegistryPath: string;
   private readonly gitWorkerBridge: CodexDesktopGitWorkerBridge;
   private activeWorkspaceRoot: string | null;
   private desktopImportPromptSeen = false;
   private persistedAtomWritePromise: Promise<void> = Promise.resolve();
+  private desktopGlobalStateWritePromise: Promise<void> = Promise.resolve();
   private nextRequestId = 0;
   private isClosing = false;
   private isInitialized = false;
@@ -318,6 +326,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     this.hostId = options.hostId ?? "local";
     this.cwd = options.cwd;
     this.codexHomePath = options.codexHomePath ?? deriveCodexHomePath();
+    this.desktopGlobalStatePath = join(this.codexHomePath, ".codex-global-state.json");
     this.persistedAtomRegistryPath =
       options.persistedAtomRegistryPath ?? derivePersistedAtomRegistryPath();
     this.workspaceRootRegistryPath =
@@ -408,6 +417,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
 
     await this.persistedAtomWritePromise.catch(() => undefined);
+    await this.desktopGlobalStateWritePromise.catch(() => undefined);
   }
 
   async forwardBridgeMessage(message: unknown): Promise<void> {
@@ -836,12 +846,20 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
   }
 
   private async restoreWorkspaceRootRegistry(): Promise<void> {
+    const desktopState = await this.loadDesktopState();
+    this.applyDesktopPinnedThreadIds(desktopState.pinnedThreadIds);
+
     try {
       const loaded = await loadWorkspaceRootRegistry(this.workspaceRootRegistryPath);
       this.workspaceRootRegistryPath = loaded.path;
       if (loaded.state) {
         this.desktopImportPromptSeen = loaded.state.desktopImportPromptSeen;
         this.applyWorkspaceRootRegistry(loaded.state);
+      }
+      if (!loaded.state || loaded.state.roots.length === 0) {
+        await this.importDesktopWorkspaceRoots(desktopState.projects);
+      } else {
+        await this.reconcileDesktopWorkspaceRoots(desktopState.projects);
       }
     } catch (error) {
       debugLog("app-server", "failed to restore workspace root registry", {
@@ -851,6 +869,83 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
 
     this.syncWorkspaceGlobalState();
+  }
+
+  private async loadDesktopState(): Promise<LoadedCodexDesktopState> {
+    try {
+      const loaded = await loadCodexDesktopState(this.desktopGlobalStatePath);
+      if (loaded.found) {
+        this.desktopGlobalStatePath = loaded.path;
+      }
+      return loaded;
+    } catch (error) {
+      debugLog("app-server", "failed to load Codex desktop state", {
+        error: normalizeError(error).message,
+      });
+      return {
+        found: false,
+        path: this.desktopGlobalStatePath,
+        projects: [],
+        pinnedThreadIds: [],
+      };
+    }
+  }
+
+  private applyDesktopPinnedThreadIds(threadIds: string[]): void {
+    this.pinnedThreadIds.clear();
+    for (const threadId of threadIds) {
+      this.pinnedThreadIds.add(threadId);
+    }
+    this.globalState.set("pinned-thread-ids", Array.from(this.pinnedThreadIds));
+  }
+
+  private async importDesktopWorkspaceRoots(projects: CodexDesktopProject[]): Promise<void> {
+    const availableProjects = projects.filter((project) => project.available);
+    if (availableProjects.length === 0) {
+      return;
+    }
+
+    this.applyDesktopWorkspaceProjects(availableProjects, []);
+    await this.persistWorkspaceRootRegistry();
+  }
+
+  private async reconcileDesktopWorkspaceRoots(projects: CodexDesktopProject[]): Promise<void> {
+    const availableProjects = projects.filter((project) => project.available);
+    if (availableProjects.length === 0) {
+      return;
+    }
+
+    this.applyDesktopWorkspaceProjects(availableProjects, Array.from(this.workspaceRoots));
+    await this.persistWorkspaceRootRegistry();
+  }
+
+  private applyDesktopWorkspaceProjects(
+    desktopProjects: CodexDesktopProject[],
+    existingRoots: string[],
+  ): void {
+    const desktopRoots = desktopProjects.map((project) => project.root);
+    const desktopRootSet = new Set(desktopRoots);
+    const browserOnlyRoots = existingRoots.filter((root) => !desktopRootSet.has(root));
+    const roots = [...desktopRoots, ...browserOnlyRoots];
+    const labels = Object.fromEntries(this.workspaceRootLabels);
+
+    for (const project of desktopProjects) {
+      labels[project.root] = project.label;
+    }
+
+    const activeProject = desktopProjects.find((project) => project.active);
+    const activeRoot =
+      activeProject?.root ??
+      (this.activeWorkspaceRoot && roots.includes(this.activeWorkspaceRoot)
+        ? this.activeWorkspaceRoot
+        : (roots[0] ?? null));
+
+    this.applyWorkspaceRootRegistry({
+      roots,
+      labels,
+      activeRoot,
+      desktopImportPromptSeen: true,
+    });
   }
 
   private async restorePersistedAtomRegistry(): Promise<void> {
@@ -1538,53 +1633,22 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
           return;
         }
 
-        const response = await fetch(new URL(message.url, "https://chatgpt.com"), {
-          method: typeof message.method === "string" ? message.method : "GET",
-          headers: buildOutboundFetchHeaders(message.headers, message.body),
-          body: normalizeRequestBody(message.body),
-          signal: controller.signal,
-        });
-        const handledResponse = await readRemoteFetchResponse(response);
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        this.emit("bridge_message", {
-          type: "fetch-response",
-          requestId: message.requestId,
-          responseType: "success",
-          status: handledResponse.status,
-          headers: handledResponse.headers,
-          bodyJsonString: JSON.stringify(handledResponse.body),
-        });
+        this.emitFetchError(
+          message.requestId,
+          501,
+          `Unsupported relative fetch URL: ${message.url}`,
+        );
         return;
       }
 
-      const response = await fetch(message.url, {
-        method: typeof message.method === "string" ? message.method : "GET",
-        headers: buildOutboundFetchHeaders(message.headers, message.body),
-        body: normalizeRequestBody(message.body),
-        signal: controller.signal,
-      });
-      const handledResponse = await readRemoteFetchResponse(response);
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      this.emit("bridge_message", {
-        type: "fetch-response",
-        requestId: message.requestId,
-        responseType: "success",
-        status: handledResponse.status,
-        headers: handledResponse.headers,
-        bodyJsonString: JSON.stringify(handledResponse.body),
-      });
+      this.emitFetchError(message.requestId, 501, `Unsupported absolute fetch URL: ${message.url}`);
     } catch (error) {
       if (controller.signal.aborted) {
         return;
       }
       const normalized = normalizeError(error);
-      this.emitFetchError(message.requestId, 500, normalized.message);
+      const status = error instanceof ForbiddenPathError ? 403 : 500;
+      this.emitFetchError(message.requestId, status, normalized.message);
     } finally {
       this.fetchRequests.delete(message.requestId);
     }
@@ -1787,6 +1851,11 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
           body: {
             roots: this.getActiveWorkspaceRoots(),
           },
+        };
+      case "projectless-thread-cwd":
+        return {
+          status: 200,
+          body: await this.readProjectlessThreadCwd(),
         };
       case "workspace-root-options":
         return {
@@ -2379,21 +2448,23 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
   }
 
   private async handleLocalEnvironmentsRequest(body: unknown): Promise<unknown> {
-    const workspaceRoot =
-      readLocalEnvironmentWorkspaceRoot(body) ?? this.activeWorkspaceRoot ?? this.cwd;
+    const workspaceRoot = this.resolveAllowedWorkspaceRoot(
+      readLocalEnvironmentWorkspaceRoot(body) ?? this.activeWorkspaceRoot,
+    );
     return await listLocalEnvironments(workspaceRoot);
   }
 
   private async handleLocalEnvironmentConfigRequest(body: unknown): Promise<unknown> {
     const configPath = readLocalEnvironmentConfigPath(body);
     if (configPath) {
-      return await readLocalEnvironmentConfig(configPath);
+      return await readLocalEnvironmentConfig(
+        this.resolveAllowedLocalEnvironmentConfigPath(configPath),
+      );
     }
 
-    const workspaceRoot = readLocalEnvironmentWorkspaceRoot(body) ?? this.activeWorkspaceRoot;
-    if (!workspaceRoot) {
-      throw new Error("Local environment workspace root is required.");
-    }
+    const workspaceRoot = this.resolveAllowedWorkspaceRoot(
+      readLocalEnvironmentWorkspaceRoot(body) ?? this.activeWorkspaceRoot,
+    );
 
     return await readLocalEnvironmentConfig(
       join(workspaceRoot, ".codex", "environments", "environment.toml"),
@@ -2406,7 +2477,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       throw new Error("Local environment config path is required.");
     }
 
-    return await loadLocalEnvironment(configPath);
+    return await loadLocalEnvironment(this.resolveAllowedLocalEnvironmentConfigPath(configPath));
   }
 
   private async handleLocalEnvironmentConfigSaveRequest(body: unknown): Promise<unknown> {
@@ -2420,7 +2491,10 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       throw new Error("Local environment config contents are required.");
     }
 
-    return await saveLocalEnvironmentConfig(configPath, raw);
+    return await saveLocalEnvironmentConfig(
+      this.resolveAllowedLocalEnvironmentConfigPath(configPath),
+      raw,
+    );
   }
 
   private async readCodexAgentsMarkdown(): Promise<{
@@ -2475,10 +2549,11 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
 
     let resolvedPath: string;
     try {
-      resolvedPath = normalizeCodexReadFilePath(path);
+      resolvedPath = await this.resolveAllowedCodexReadFilePath(path);
     } catch (error) {
+      const status = error instanceof ForbiddenPathError ? 403 : 400;
       return {
-        status: 400,
+        status,
         body: {
           error: normalizeError(error).message,
         },
@@ -2524,6 +2599,65 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
 
       throw error;
     }
+  }
+
+  private async resolveAllowedCodexReadFilePath(path: string): Promise<string> {
+    const resolvedPath = normalizeCodexReadFilePath(path);
+    if (!isPathInsideAnyRoot(resolvedPath, this.getAllowedReadRoots())) {
+      throw new ForbiddenPathError("File path is outside Pocodex's allowed read roots.");
+    }
+
+    const realPath = await realpath(resolvedPath).catch(() => resolvedPath);
+    if (!isPathInsideAnyRoot(realPath, await this.getRealAllowedReadRoots())) {
+      throw new ForbiddenPathError("File path is outside Pocodex's allowed read roots.");
+    }
+
+    return resolvedPath;
+  }
+
+  private resolveAllowedWorkspaceRoot(path: string | null): string {
+    if (!path) {
+      throw new Error("Local environment workspace root is required.");
+    }
+
+    const resolvedPath = normalizeAbsoluteHostPath(path, "Local environment workspace root");
+    if (!isPathInsideAnyRoot(resolvedPath, this.getRegisteredWorkspaceRoots())) {
+      throw new ForbiddenPathError(
+        "Local environment workspace root is not registered in Pocodex.",
+      );
+    }
+
+    return resolvedPath;
+  }
+
+  private resolveAllowedLocalEnvironmentConfigPath(path: string): string {
+    const resolvedPath = normalizeLocalEnvironmentConfigHostPath(path);
+    if (!isPathInsideAnyRoot(resolvedPath, this.getRegisteredWorkspaceRoots())) {
+      throw new ForbiddenPathError(
+        "Local environment config path is outside registered workspace roots.",
+      );
+    }
+
+    return resolvedPath;
+  }
+
+  private getAllowedReadRoots(): string[] {
+    return uniqueStrings([
+      ...this.getRegisteredWorkspaceRoots(),
+      this.codexHomePath,
+      dirname(this.persistedAtomRegistryPath),
+      dirname(this.workspaceRootRegistryPath),
+    ]).map((root) => resolve(root));
+  }
+
+  private async getRealAllowedReadRoots(): Promise<string[]> {
+    return await Promise.all(
+      this.getAllowedReadRoots().map(async (root) => await realpath(root).catch(() => root)),
+    );
+  }
+
+  private getRegisteredWorkspaceRoots(): string[] {
+    return Array.from(this.workspaceRoots).map((root) => resolve(root));
   }
 
   private readDeveloperInstructions(body: unknown): string | null {
@@ -2620,6 +2754,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
           this.pinnedThreadIds.add(value);
         }
       }
+      this.queueDesktopPinnedThreadIdsWrite();
       this.emitBridgeMessage({
         type: "pinned-threads-updated",
       });
@@ -2649,6 +2784,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
 
     this.globalState.set("pinned-thread-ids", Array.from(this.pinnedThreadIds));
+    this.queueDesktopPinnedThreadIdsWrite();
     this.emitBridgeMessage({
       type: "pinned-threads-updated",
     });
@@ -2671,10 +2807,27 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
 
     this.globalState.set("pinned-thread-ids", Array.from(this.pinnedThreadIds));
+    this.queueDesktopPinnedThreadIdsWrite();
     this.emitBridgeMessage({
       type: "pinned-threads-updated",
     });
     return {};
+  }
+
+  private queueDesktopPinnedThreadIdsWrite(): void {
+    const threadIds = Array.from(this.pinnedThreadIds);
+    this.desktopGlobalStateWritePromise = this.desktopGlobalStateWritePromise
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await saveCodexDesktopPinnedThreadIds(this.desktopGlobalStatePath, threadIds);
+        } catch (error) {
+          debugLog("app-server", "failed to persist desktop pinned thread ids", {
+            error: normalizeError(error).message,
+            path: this.desktopGlobalStatePath,
+          });
+        }
+      });
   }
 
   private async addWorkspaceRootOption(body: unknown): Promise<{
@@ -2833,6 +2986,21 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
     }
 
     return roots;
+  }
+
+  private async readProjectlessThreadCwd(): Promise<{
+    cwd: string;
+    outputDirectory: string;
+    workspaceRoot: string;
+  }> {
+    const workspaceRoot = this.getActiveWorkspaceRoots()[0] ?? this.cwd;
+    const outputDirectory = join(this.codexHomePath, "pocodex", "projectless-output");
+    await mkdir(outputDirectory, { recursive: true });
+    return {
+      cwd: workspaceRoot,
+      outputDirectory,
+      workspaceRoot,
+    };
   }
 
   private getGitOriginFallbackDirectories(): string[] {
@@ -4215,9 +4383,7 @@ function convertWorkspaceRootWslUncPathToLinux(path: string): string | null {
 }
 
 function isRunningInWsl(): boolean {
-  return (
-    process.platform === "linux" && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP)
-  );
+  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
 }
 
 function normalizeWorkspaceRootPickerPathError(error: unknown): Error {
@@ -4584,6 +4750,54 @@ function normalizeCodexReadFilePath(path: string): string {
   }
 
   return resolve(expandedPath);
+}
+
+class ForbiddenPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ForbiddenPathError";
+  }
+}
+
+function normalizeAbsoluteHostPath(path: string, label: string): string {
+  const trimmedPath = path.trim();
+  if (trimmedPath.length === 0) {
+    throw new Error(`${label} is required.`);
+  }
+
+  const expandedPath = normalizeWorkspaceRootHostPath(expandWorkspaceRootPickerHome(trimmedPath));
+  if (!isAbsolute(expandedPath)) {
+    throw new Error(`${label} must be absolute.`);
+  }
+
+  return resolve(expandedPath);
+}
+
+function normalizeLocalEnvironmentConfigHostPath(path: string): string {
+  const normalizedPath = normalizeAbsoluteHostPath(path, "Local environment config path");
+  const environmentsDirectory = dirname(normalizedPath);
+  const codexDirectory = dirname(environmentsDirectory);
+
+  if (
+    basename(normalizedPath) !== "environment.toml" ||
+    basename(environmentsDirectory) !== "environments" ||
+    basename(codexDirectory) !== ".codex"
+  ) {
+    throw new Error("Invalid local environment config path.");
+  }
+
+  return normalizedPath;
+}
+
+function isPathInsideAnyRoot(path: string, roots: string[]): boolean {
+  const resolvedPath = resolve(path);
+  return roots.some((root) => isPathInsideRoot(resolvedPath, root));
+}
+
+function isPathInsideRoot(path: string, root: string): boolean {
+  const resolvedRoot = resolve(root);
+  const relativePath = relative(resolvedRoot, path);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
 }
 
 function readFetchErrorMessage(body: unknown, fallback: string): string {

--- a/src/lib/bootstrap-script.ts
+++ b/src/lib/bootstrap-script.ts
@@ -296,22 +296,20 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   }
 
   function persistSessionToken(token: string): void {
-    for (const storageName of ["sessionStorage", "localStorage"] as const) {
-      const storage = getStorage(storageName);
-      if (!storage) {
-        continue;
-      }
+    const storage = getStorage("sessionStorage");
+    if (!storage) {
+      return;
+    }
 
-      if (token) {
-        storage.setItem(TOKEN_STORAGE_KEY, token);
-        continue;
-      }
+    if (token) {
+      storage.setItem(TOKEN_STORAGE_KEY, token);
+      return;
+    }
 
-      if (typeof storage.removeItem === "function") {
-        storage.removeItem(TOKEN_STORAGE_KEY);
-      } else {
-        storage.setItem(TOKEN_STORAGE_KEY, "");
-      }
+    if (typeof storage.removeItem === "function") {
+      storage.removeItem(TOKEN_STORAGE_KEY);
+    } else {
+      storage.setItem(TOKEN_STORAGE_KEY, "");
     }
   }
 
@@ -828,12 +826,31 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       return;
     }
 
-    const desiredMode = sidebarModeFromHost ?? "expanded";
     const currentMode = readSidebarMode();
     if (!currentMode) {
       if (retriesRemaining > 0) {
         scheduleSidebarModeReconcile(retriesRemaining - 1, 50);
       }
+      return;
+    }
+
+    if (sidebarModeFromHost === null && isMobileSidebarViewport()) {
+      hasRestoredSidebarMode = true;
+      if (isSidebarModeInteractionArmed) {
+        persistSidebarMode(currentMode);
+      }
+      return;
+    }
+
+    const desiredMode = sidebarModeFromHost ?? "expanded";
+    if (
+      isMobileSidebarViewport() &&
+      desiredMode === "expanded" &&
+      currentMode === "collapsed" &&
+      !isSidebarModeInteractionArmed
+    ) {
+      persistSidebarMode("collapsed");
+      hasRestoredSidebarMode = true;
       return;
     }
 
@@ -1002,12 +1019,35 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
   function isSidebarToggleTrigger(element: Element): boolean {
     const ariaLabel = element.getAttribute("aria-label")?.trim().toLowerCase() ?? "";
-    if (ariaLabel === "hide sidebar" || ariaLabel === "show sidebar") {
+    if (isSidebarToggleLabel(ariaLabel)) {
       return true;
     }
 
     const title = element.getAttribute("title")?.trim().toLowerCase() ?? "";
-    return title === "hide sidebar" || title === "show sidebar";
+    if (isSidebarToggleLabel(title)) {
+      return true;
+    }
+
+    return isSidebarToggleLabel(element.textContent?.trim().toLowerCase() ?? "");
+  }
+
+  function isSidebarToggleLabel(label: string): boolean {
+    return (
+      label === "hide sidebar" ||
+      label === "show sidebar" ||
+      label === "close sidebar" ||
+      label === "open sidebar" ||
+      label === "collapse sidebar" ||
+      label === "expand sidebar" ||
+      label === "toggle sidebar" ||
+      label.startsWith("hide sidebar ") ||
+      label.startsWith("show sidebar ") ||
+      label.startsWith("close sidebar ") ||
+      label.startsWith("open sidebar ") ||
+      label.startsWith("collapse sidebar ") ||
+      label.startsWith("expand sidebar ") ||
+      label.startsWith("toggle sidebar ")
+    );
   }
 
   function isSidebarToggleShortcut(event: KeyboardEvent): boolean {
@@ -1918,7 +1958,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
   }
 
   async function callPocodexIpc(method: string, params?: unknown): Promise<unknown> {
-    const response = await nativeFetch("/ipc-request", {
+    const response = await nativeFetch(getIpcRequestUrl(), {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -2917,7 +2957,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
       persistSessionToken(tokenFromQuery);
       return tokenFromQuery;
     }
-    return readStoredTokenValue("sessionStorage") || readStoredTokenValue("localStorage");
+    return readStoredTokenValue("sessionStorage");
   }
 
   async function registerPwaServiceWorker(): Promise<void> {
@@ -3042,6 +3082,15 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
 
   function getSessionCheckUrl(token: string): string {
     const url = new URL(SESSION_CHECK_PATH, window.location.href);
+    if (token) {
+      url.searchParams.set("token", token);
+    }
+    return `${url.pathname}${url.search}`;
+  }
+
+  function getIpcRequestUrl(): string {
+    const url = new URL("/ipc-request", window.location.href);
+    const token = getStoredToken();
     if (token) {
       url.searchParams.set("token", token);
     }
@@ -3510,6 +3559,16 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
         });
         return;
       }
+      if (isRecord(message) && message.type === "toggle-sidebar") {
+        armSidebarModeInteraction();
+        window.setTimeout(() => {
+          const currentMode = readSidebarMode();
+          if (currentMode) {
+            persistSidebarMode(currentMode);
+          }
+          scheduleSidebarModeReconcile(5);
+        }, 0);
+      }
       syncRestorableTerminalAttachments(message, "outgoing");
       sendEnvelope({ type: "bridge_message", message });
       syncThreadQueryWithBridgeMessage(message);
@@ -3549,7 +3608,7 @@ function bootstrapPocodexInBrowser(config: BootstrapScriptConfig): void {
         init?.method ??
         (input instanceof Request ? (input as Request & { method?: string }).method : undefined) ??
         "POST";
-      return nativeFetch("/ipc-request", {
+      return nativeFetch(getIpcRequestUrl(), {
         method,
         body: init?.body,
         headers: init?.headers,

--- a/src/lib/codex-desktop-projects.ts
+++ b/src/lib/codex-desktop-projects.ts
@@ -1,5 +1,5 @@
-import { readFile, stat } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import process from "node:process";
 
 import { deriveCodexHomePath, listCodexHomePathCandidates } from "./codex-home.js";
@@ -17,6 +17,10 @@ export interface LoadedCodexDesktopProjects {
   projects: CodexDesktopProject[];
 }
 
+export interface LoadedCodexDesktopState extends LoadedCodexDesktopProjects {
+  pinnedThreadIds: string[];
+}
+
 export function deriveCodexDesktopGlobalStatePath(): string {
   return join(deriveCodexHomePath(), ".codex-global-state.json");
 }
@@ -24,14 +28,25 @@ export function deriveCodexDesktopGlobalStatePath(): string {
 export async function loadCodexDesktopProjects(
   globalStatePath: string,
 ): Promise<LoadedCodexDesktopProjects> {
+  const state = await loadCodexDesktopState(globalStatePath);
+  return {
+    found: state.found,
+    path: state.path,
+    projects: state.projects,
+  };
+}
+
+export async function loadCodexDesktopState(
+  globalStatePath: string,
+): Promise<LoadedCodexDesktopState> {
   for (const candidatePath of listDesktopGlobalStatePathCandidates(globalStatePath)) {
     try {
       const raw = await readFile(candidatePath, "utf8");
-      const projects = await parseCodexDesktopProjects(raw);
+      const state = await parseCodexDesktopState(raw);
       return {
         found: true,
         path: candidatePath,
-        projects,
+        ...state,
       };
     } catch (error) {
       if (isMissingFileError(error)) {
@@ -45,22 +60,57 @@ export async function loadCodexDesktopProjects(
     found: false,
     path: globalStatePath,
     projects: [],
+    pinnedThreadIds: [],
   };
 }
 
-async function parseCodexDesktopProjects(raw: string): Promise<CodexDesktopProject[]> {
+export async function saveCodexDesktopPinnedThreadIds(
+  globalStatePath: string,
+  pinnedThreadIds: string[],
+): Promise<void> {
+  let parsed: Record<string, unknown> = {};
+  try {
+    const raw = await readFile(globalStatePath, "utf8");
+    const value: unknown = JSON.parse(raw);
+    if (isJsonRecord(value)) {
+      parsed = { ...value };
+    }
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+  }
+
+  parsed["pinned-thread-ids"] = uniqueStrings(pinnedThreadIds);
+  await mkdir(dirname(globalStatePath), { recursive: true });
+  await writeFile(globalStatePath, JSON.stringify(parsed), "utf8");
+}
+
+async function parseCodexDesktopState(raw: string): Promise<{
+  projects: CodexDesktopProject[];
+  pinnedThreadIds: string[];
+}> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return [];
+    return {
+      projects: [],
+      pinnedThreadIds: [],
+    };
   }
 
   if (!isJsonRecord(parsed)) {
-    return [];
+    return {
+      projects: [],
+      pinnedThreadIds: [],
+    };
   }
 
-  const roots = uniqueStrings(parsed["electron-saved-workspace-roots"]);
+  const roots = mergeDesktopProjectOrder(
+    parsed["project-order"],
+    parsed["electron-saved-workspace-roots"],
+  );
   const activeRoots = new Set(uniqueStrings(parsed["active-workspace-roots"]));
   const labels = isJsonRecord(parsed["electron-workspace-root-labels"])
     ? parsed["electron-workspace-root-labels"]
@@ -83,14 +133,28 @@ async function parseCodexDesktopProjects(raw: string): Promise<CodexDesktopProje
     });
   }
 
-  return Promise.all(
-    Array.from(projectsByRoot.entries()).map(async ([root, project]) => ({
-      root,
-      label: resolveDesktopProjectLabel(root, project.label),
-      active: project.active,
-      available: await isDirectory(root),
-    })),
-  );
+  return {
+    projects: await Promise.all(
+      Array.from(projectsByRoot.entries()).map(async ([root, project]) => ({
+        root,
+        label: resolveDesktopProjectLabel(root, project.label),
+        active: project.active,
+        available: await isDirectory(root),
+      })),
+    ),
+    pinnedThreadIds: uniqueStrings(parsed["pinned-thread-ids"]),
+  };
+}
+
+function mergeDesktopProjectOrder(order: unknown, savedRoots: unknown): string[] {
+  const saved = uniqueStrings(savedRoots);
+  if (saved.length === 0) {
+    return [];
+  }
+
+  const savedSet = new Set(saved);
+  const ordered = uniqueStrings(order).filter((root) => savedSet.has(root));
+  return [...ordered, ...saved.filter((root) => !ordered.includes(root))];
 }
 
 function resolveDesktopProjectLabel(root: string, label: unknown): string {
@@ -208,7 +272,5 @@ function convertWslUncPathToLinux(path: string): string | null {
 }
 
 function isRunningInWsl(): boolean {
-  return (
-    process.platform === "linux" && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP)
-  );
+  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
 }

--- a/src/lib/codex-home.ts
+++ b/src/lib/codex-home.ts
@@ -22,9 +22,7 @@ export function listCodexHomePathCandidates(): string[] {
 }
 
 function isRunningInWsl(): boolean {
-  return (
-    process.platform === "linux" && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP)
-  );
+  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
 }
 
 function normalizeEnvironmentPath(path: string | undefined): string | null {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -225,6 +225,20 @@ export class PocodexServer {
     }
 
     if (url.pathname === "/ipc-request") {
+      if (!this.isAuthorized(url.searchParams.get("token"))) {
+        response.statusCode = 401;
+        response.setHeader("Cache-Control", "no-store");
+        response.setHeader("Content-Type", "application/json; charset=utf-8");
+        response.end(
+          JSON.stringify({
+            requestId: "",
+            type: "response",
+            resultType: "error",
+            error: "Unauthorized IPC request.",
+          }),
+        );
+        return;
+      }
       await this.handleIpcRequest(request, response);
       return;
     }
@@ -276,6 +290,12 @@ export class PocodexServer {
       return;
     }
 
+    if (!this.isAllowedWebSocketOrigin(request.headers.origin, request.headers.host)) {
+      socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
     this.wsServer.handleUpgrade(request, socket, head, (upgradedSocket) => {
       this.wsServer.emit("connection", upgradedSocket, request);
     });
@@ -316,7 +336,24 @@ export class PocodexServer {
   }
 
   private isAuthorized(requestToken: string | null): boolean {
-    return this.options.token.length === 0 || requestToken === this.options.token;
+    return this.options.token.length > 0 && requestToken === this.options.token;
+  }
+
+  private isAllowedWebSocketOrigin(origin: string | undefined, host: string | undefined): boolean {
+    if (!origin) {
+      return true;
+    }
+
+    if (!host) {
+      return false;
+    }
+
+    try {
+      const originUrl = new URL(origin);
+      return originUrl.host.toLowerCase() === host.toLowerCase();
+    } catch {
+      return false;
+    }
   }
 
   private async handleSocketMessage(session: BrowserSession, raw: string): Promise<void> {

--- a/test/app-server-bridge-basic.test.ts
+++ b/test/app-server-bridge-basic.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, it, vi } from "vitest";
@@ -410,8 +410,61 @@ describeAppServerBridge(({ children }) => {
     await bridge.close();
   });
 
+  it("hydrates and persists pinned threads through Codex Desktop global state", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-pinned-threads-"));
+    tempDirs.push(tempDirectory);
+    const codexHome = join(tempDirectory, "codex-home");
+    await mkdir(codexHome, { recursive: true });
+    const globalStatePath = join(codexHome, ".codex-global-state.json");
+    await writeFile(
+      globalStatePath,
+      JSON.stringify({
+        "pinned-thread-ids": ["thr_existing"],
+      }),
+      "utf8",
+    );
+
+    const bridge = await createBridge(children, {
+      codexHomePath: codexHome,
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-pins",
+      method: "POST",
+      url: "vscode://codex/list-pinned-threads",
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "pin-new",
+      method: "POST",
+      url: "vscode://codex/set-thread-pinned",
+      body: JSON.stringify({ threadId: "thr_new", pinned: true }),
+    });
+
+    await waitForCondition(() => emittedMessages.length >= 3);
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-pins")).toEqual({
+      threadIds: ["thr_existing"],
+    });
+
+    await bridge.close();
+
+    await expect(readFile(globalStatePath, "utf8").then(JSON.parse)).resolves.toMatchObject({
+      "pinned-thread-ids": ["thr_existing", "thr_new"],
+    });
+  });
+
   it("publishes shared object updates and opens the onboarding workspace picker", async () => {
-    const bridge = await createBridge(children);
+    const codexHome = await mkdtemp(join(tmpdir(), "pocodex-codex-home-"));
+    tempDirs.push(codexHome);
+
+    const bridge = await createBridge(children, { codexHomePath: codexHome });
     const emittedMessages: unknown[] = [];
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);

--- a/test/app-server-bridge-host-data.test.ts
+++ b/test/app-server-bridge-host-data.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, it } from "vitest";
@@ -24,7 +24,6 @@ describeAppServerBridge(({ children }) => {
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
     });
-
     await bridge.forwardBridgeMessage({
       type: "fetch",
       requestId: "fetch-os",
@@ -137,7 +136,6 @@ describeAppServerBridge(({ children }) => {
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
     });
-
     await bridge.forwardBridgeMessage({
       type: "fetch",
       requestId: "fetch-thread-title",
@@ -158,6 +156,43 @@ describeAppServerBridge(({ children }) => {
     expect(getFetchJsonBody(emittedMessages, "fetch-thread-title")).toEqual({
       title: "explore this repo and report back the main entry points and…",
     });
+
+    await bridge.close();
+  });
+
+  it("returns a projectless thread cwd and output directory for new chat startup", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "pocodex-codex-home-"));
+    tempDirs.push(codexHome);
+
+    const bridge = await createBridge(children, { codexHomePath: codexHome });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-projectless-thread-cwd",
+      method: "POST",
+      url: "vscode://codex/projectless-thread-cwd",
+      body: JSON.stringify({
+        params: {
+          prompt: "say connected",
+        },
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-projectless-thread-cwd")),
+    );
+
+    const outputDirectory = join(codexHome, "pocodex", "projectless-output");
+    expect(getFetchJsonBody(emittedMessages, "fetch-projectless-thread-cwd")).toEqual({
+      cwd: TEST_WORKSPACE_ROOT,
+      outputDirectory,
+      workspaceRoot: TEST_WORKSPACE_ROOT,
+    });
+    expect((await stat(outputDirectory)).isDirectory()).toBe(true);
 
     await bridge.close();
   });
@@ -204,7 +239,6 @@ description: Review lint issues quickly.
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
     });
-
     await bridge.forwardBridgeMessage({
       type: "fetch",
       requestId: "fetch-recommended-skills",
@@ -305,12 +339,14 @@ description: Review lint issues quickly.
   });
 
   it("reads skill contents through the webview read-file contract", async () => {
-    const skillDirectory = await mkdtemp(join(tmpdir(), "pocodex-skill-"));
-    tempDirs.push(skillDirectory);
+    const codexHome = await mkdtemp(join(tmpdir(), "pocodex-codex-home-"));
+    tempDirs.push(codexHome);
+    const skillDirectory = join(codexHome, "vendor_imports", "skills", "demo");
+    await mkdir(skillDirectory, { recursive: true });
     const skillPath = join(skillDirectory, "SKILL.md");
     await writeFile(skillPath, "# Demo Skill\n\nUse concise output.\n", "utf8");
 
-    const bridge = await createBridge(children);
+    const bridge = await createBridge(children, { codexHomePath: codexHome });
     const emittedMessages: unknown[] = [];
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
@@ -334,6 +370,120 @@ description: Review lint issues quickly.
       path: skillPath,
       contents: "# Demo Skill\n\nUse concise output.\n",
     });
+
+    await bridge.close();
+  });
+
+  it("allows read-file under a registered workspace and rejects unsafe paths", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-read-file-"));
+    tempDirs.push(tempDirectory);
+    const projectRoot = join(tempDirectory, "project-read-file");
+    await mkdir(projectRoot, { recursive: true });
+    const workspaceFile = join(projectRoot, "README.md");
+    await writeFile(workspaceFile, "# Project\n", "utf8");
+
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+    await registerWorkspaceRoot(bridge, emittedMessages, projectRoot);
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-read-file-workspace",
+      method: "POST",
+      url: "vscode://codex/read-file",
+      body: JSON.stringify({
+        params: {
+          path: workspaceFile,
+        },
+      }),
+    });
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-read-file-outside",
+      method: "POST",
+      url: "vscode://codex/read-file",
+      body: JSON.stringify({
+        params: {
+          path: "/etc/hosts",
+        },
+      }),
+    });
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-read-file-directory",
+      method: "POST",
+      url: "vscode://codex/read-file",
+      body: JSON.stringify({
+        params: {
+          path: projectRoot,
+        },
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-read-file-directory")),
+    );
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-read-file-workspace")).toEqual({
+      path: workspaceFile,
+      contents: "# Project\n",
+    });
+    expect(getFetchResponse(emittedMessages, "fetch-read-file-outside")).toMatchObject({
+      type: "fetch-response",
+      requestId: "fetch-read-file-outside",
+      responseType: "error",
+      status: 403,
+      error: "File path is outside Pocodex's allowed read roots.",
+    });
+    expect(getFetchResponse(emittedMessages, "fetch-read-file-directory")).toMatchObject({
+      type: "fetch-response",
+      requestId: "fetch-read-file-directory",
+      responseType: "error",
+      status: 400,
+      error: "File path must point to a file.",
+    });
+
+    await bridge.close();
+  });
+
+  it("rejects unsupported browser bridge fetch URLs without proxying them", async () => {
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    const urls = [
+      "http://127.0.0.1:8080/status",
+      "http://192.168.1.20/admin",
+      "http://169.254.169.254/latest/meta-data",
+      "file:///etc/hosts",
+      "https://example.com/api",
+    ];
+
+    for (const [index, url] of urls.entries()) {
+      await bridge.forwardBridgeMessage({
+        type: "fetch",
+        requestId: `fetch-unsupported-${index}`,
+        method: "GET",
+        url,
+      });
+    }
+
+    await waitForCondition(() => Boolean(getFetchResponse(emittedMessages, "fetch-unsupported-4")));
+
+    for (const [index, url] of urls.entries()) {
+      expect(getFetchResponse(emittedMessages, `fetch-unsupported-${index}`)).toMatchObject({
+        type: "fetch-response",
+        requestId: `fetch-unsupported-${index}`,
+        responseType: "error",
+        status: 501,
+        error: `Unsupported absolute fetch URL: ${url}`,
+      });
+    }
 
     await bridge.close();
   });
@@ -408,6 +558,7 @@ description: Review lint issues quickly.
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
     });
+    await registerWorkspaceRoot(bridge, emittedMessages, projectRoot);
 
     await bridge.forwardBridgeMessage({
       type: "fetch",
@@ -480,6 +631,7 @@ description: Review lint issues quickly.
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
     });
+    await registerWorkspaceRoot(bridge, emittedMessages, projectRoot);
 
     await bridge.forwardBridgeMessage({
       type: "fetch",
@@ -563,6 +715,7 @@ description: Review lint issues quickly.
     bridge.on("bridge_message", (message) => {
       emittedMessages.push(message);
     });
+    await registerWorkspaceRoot(bridge, emittedMessages, projectRoot);
 
     await bridge.forwardBridgeMessage({
       type: "fetch",
@@ -687,4 +840,70 @@ description: Review lint issues quickly.
 
     await bridge.close();
   });
+
+  it("rejects local environment config paths outside registered workspace roots", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-local-environments-"));
+    tempDirs.push(tempDirectory);
+    const projectRoot = join(tempDirectory, "project-zeta");
+    const outsideRoot = join(tempDirectory, "outside-project");
+    await mkdir(projectRoot, { recursive: true });
+    await mkdir(join(outsideRoot, ".codex", "environments"), { recursive: true });
+    const outsideEnvironmentPath = join(outsideRoot, ".codex", "environments", "environment.toml");
+
+    const bridge = await createBridge(children);
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+    await registerWorkspaceRoot(bridge, emittedMessages, projectRoot);
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-local-environment-outside-save",
+      method: "POST",
+      url: "vscode://codex/local-environment-config-save",
+      body: JSON.stringify({
+        params: {
+          configPath: outsideEnvironmentPath,
+          raw: 'name = "Outside"\nversion = 1\n',
+        },
+      }),
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-local-environment-outside-save")),
+    );
+
+    expect(getFetchResponse(emittedMessages, "fetch-local-environment-outside-save")).toMatchObject(
+      {
+        type: "fetch-response",
+        requestId: "fetch-local-environment-outside-save",
+        responseType: "error",
+        status: 403,
+        error: "Local environment config path is outside registered workspace roots.",
+      },
+    );
+
+    await bridge.close();
+  });
 });
+
+async function registerWorkspaceRoot(
+  bridge: {
+    forwardBridgeMessage: (message: unknown) => Promise<void>;
+  },
+  emittedMessages: unknown[],
+  root: string,
+): Promise<void> {
+  const requestId = `register-workspace-root:${root}`;
+  await bridge.forwardBridgeMessage({
+    type: "fetch",
+    requestId,
+    method: "POST",
+    url: "vscode://codex/add-workspace-root-option",
+    body: JSON.stringify({
+      root,
+    }),
+  });
+  await waitForCondition(() => Boolean(getFetchResponse(emittedMessages, requestId)));
+}

--- a/test/app-server-bridge-workspace.test.ts
+++ b/test/app-server-bridge-workspace.test.ts
@@ -21,6 +21,8 @@ describeAppServerBridge(({ children }) => {
   it("treats a missing workspace registry as pristine with no projects", async () => {
     const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-workspace-roots-"));
     tempDirs.push(tempDirectory);
+    const codexHome = join(tempDirectory, "codex-home");
+    await mkdir(codexHome, { recursive: true });
     const workspaceRootRegistryPath = join(tempDirectory, "workspace-roots.json");
     mockLocalThreadList.data = [
       {
@@ -34,6 +36,7 @@ describeAppServerBridge(({ children }) => {
     ];
 
     const bridge = await createBridge(children, {
+      codexHomePath: codexHome,
       workspaceRootRegistryPath,
     });
     const emittedMessages: unknown[] = [];
@@ -67,6 +70,201 @@ describeAppServerBridge(({ children }) => {
     });
 
     expect(children.at(-1)?.writes ?? "").not.toContain('"method":"thread/list"');
+
+    await bridge.close();
+  });
+
+  it("imports Codex Desktop workspace roots when the Pocodex registry is missing", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-workspace-roots-"));
+    tempDirs.push(tempDirectory);
+    const codexHome = join(tempDirectory, "codex-home");
+    const workspaceRootRegistryPath = join(codexHome, "pocodex", "workspace-roots.json");
+    const projectAlpha = join(tempDirectory, "project-alpha");
+    const projectBeta = join(tempDirectory, "project-beta");
+    const missingProject = join(tempDirectory, "missing-project");
+    await mkdir(projectAlpha, { recursive: true });
+    await mkdir(projectBeta, { recursive: true });
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      join(codexHome, ".codex-global-state.json"),
+      JSON.stringify({
+        "electron-saved-workspace-roots": [projectAlpha, missingProject, projectBeta],
+        "active-workspace-roots": [projectBeta],
+        "electron-workspace-root-labels": {
+          [projectAlpha]: "Alpha",
+          [projectBeta]: "Beta",
+        },
+      }),
+      "utf8",
+    );
+
+    const bridge = await createBridge(children, {
+      codexHomePath: codexHome,
+      workspaceRootRegistryPath,
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-active-roots",
+      method: "POST",
+      url: "vscode://codex/active-workspace-roots",
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-root-options",
+      method: "POST",
+      url: "vscode://codex/workspace-root-options",
+    });
+
+    await waitForCondition(() => emittedMessages.length >= 2);
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-active-roots")).toEqual({
+      roots: [projectBeta, projectAlpha],
+    });
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-root-options")).toEqual({
+      roots: [projectAlpha, projectBeta],
+      labels: {
+        [projectAlpha]: "Alpha",
+        [projectBeta]: "Beta",
+      },
+    });
+    await expect(readFile(workspaceRootRegistryPath, "utf8")).resolves.toContain(
+      `"activeRoot": "${projectBeta}"`,
+    );
+    await expect(readFile(workspaceRootRegistryPath, "utf8")).resolves.not.toContain(
+      missingProject,
+    );
+
+    await bridge.close();
+  });
+
+  it("imports Codex Desktop workspace roots when the Pocodex registry is empty", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-workspace-roots-"));
+    tempDirs.push(tempDirectory);
+    const codexHome = join(tempDirectory, "codex-home");
+    await mkdir(codexHome, { recursive: true });
+    const workspaceRootRegistryPath = await writeWorkspaceRootRegistry(codexHome, {
+      roots: [],
+      labels: {},
+      activeRoot: null,
+      desktopImportPromptSeen: false,
+    });
+    const projectRoot = join(tempDirectory, "project-gamma");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(
+      join(codexHome, ".codex-global-state.json"),
+      JSON.stringify({
+        "electron-saved-workspace-roots": [projectRoot],
+      }),
+      "utf8",
+    );
+
+    const bridge = await createBridge(children, {
+      codexHomePath: codexHome,
+      workspaceRootRegistryPath,
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-root-options",
+      method: "POST",
+      url: "vscode://codex/workspace-root-options",
+    });
+
+    await waitForCondition(() => emittedMessages.length >= 1);
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-root-options")).toEqual({
+      roots: [projectRoot],
+      labels: {
+        [projectRoot]: "project-gamma",
+      },
+    });
+
+    await bridge.close();
+  });
+
+  it("reconciles an existing Pocodex registry with Codex Desktop project order", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-workspace-roots-"));
+    tempDirs.push(tempDirectory);
+    const codexHome = join(tempDirectory, "codex-home");
+    const projectAlpha = join(tempDirectory, "project-alpha");
+    const projectBeta = join(tempDirectory, "project-beta");
+    const browserOnlyProject = join(tempDirectory, "browser-only");
+    await mkdir(projectAlpha, { recursive: true });
+    await mkdir(projectBeta, { recursive: true });
+    await mkdir(browserOnlyProject, { recursive: true });
+    await mkdir(codexHome, { recursive: true });
+    const workspaceRootRegistryPath = await writeWorkspaceRootRegistry(codexHome, {
+      roots: [projectAlpha, browserOnlyProject, projectBeta],
+      labels: {
+        [projectAlpha]: "Old Alpha",
+        [projectBeta]: "Old Beta",
+        [browserOnlyProject]: "Browser Only",
+      },
+      activeRoot: browserOnlyProject,
+      desktopImportPromptSeen: true,
+    });
+    await writeFile(
+      join(codexHome, ".codex-global-state.json"),
+      JSON.stringify({
+        "electron-saved-workspace-roots": [projectAlpha, projectBeta],
+        "project-order": [projectBeta, projectAlpha],
+        "active-workspace-roots": [projectAlpha],
+        "electron-workspace-root-labels": {
+          [projectAlpha]: "Alpha",
+          [projectBeta]: "Beta",
+        },
+      }),
+      "utf8",
+    );
+
+    const bridge = await createBridge(children, {
+      codexHomePath: codexHome,
+      workspaceRootRegistryPath,
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-active-roots",
+      method: "POST",
+      url: "vscode://codex/active-workspace-roots",
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-root-options",
+      method: "POST",
+      url: "vscode://codex/workspace-root-options",
+    });
+
+    await waitForCondition(() => emittedMessages.length >= 2);
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-active-roots")).toEqual({
+      roots: [projectAlpha, projectBeta, browserOnlyProject],
+    });
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-root-options")).toEqual({
+      roots: [projectBeta, projectAlpha, browserOnlyProject],
+      labels: {
+        [projectAlpha]: "Alpha",
+        [projectBeta]: "Beta",
+        [browserOnlyProject]: "Browser Only",
+      },
+    });
 
     await bridge.close();
   });

--- a/test/bootstrap-script.test.ts
+++ b/test/bootstrap-script.test.ts
@@ -548,6 +548,7 @@ function createBootstrapHarness(
   options: {
     href?: string;
     localStorageEntries?: Record<string, string>;
+    sessionStorageEntries?: Record<string, string>;
     mobile?: boolean;
   } = {},
 ) {
@@ -555,7 +556,9 @@ function createBootstrapHarness(
   const localStorageEntries = new Map<string, string>(
     Object.entries(options.localStorageEntries ?? {}),
   );
-  const sessionStorageEntries = new Map<string, string>();
+  const sessionStorageEntries = new Map<string, string>(
+    Object.entries(options.sessionStorageEntries ?? {}),
+  );
   const serviceWorkerRegistrations: Array<{
     scriptUrl: string;
     options?: { scope?: string; updateViaCache?: "all" | "imports" | "none" };
@@ -786,6 +789,9 @@ function createBootstrapHarness(
     getLocalStorageValue(key: string): string | null {
       return localStorageEntries.get(key) ?? null;
     },
+    getSessionStorageValue(key: string): string | null {
+      return sessionStorageEntries.get(key) ?? null;
+    },
     getServiceWorkerRegistrations(): Array<{
       scriptUrl: string;
       options?: { scope?: string; updateViaCache?: "all" | "imports" | "none" };
@@ -951,7 +957,7 @@ describe("renderBootstrapScript", () => {
     expect(harness.document.documentElement.dataset.pocodexSettingsShell).toBe("true");
   });
 
-  it("persists the session token for standalone launches without a token query", () => {
+  it("stores the session token only for the current browser session", () => {
     const script = renderBootstrapScript({
       sentryOptions: {
         buildFlavor: "stable",
@@ -965,11 +971,12 @@ describe("renderBootstrapScript", () => {
 
     const firstHarness = createBootstrapHarness();
     firstHarness.run(script);
-    expect(firstHarness.getLocalStorageValue("__pocodex_token")).toBe("secret");
+    expect(firstHarness.getSessionStorageValue("__pocodex_token")).toBe("secret");
+    expect(firstHarness.getLocalStorageValue("__pocodex_token")).toBeNull();
 
     const standaloneHarness = createBootstrapHarness({
       href: "http://127.0.0.1:8787/",
-      localStorageEntries: {
+      sessionStorageEntries: {
         __pocodex_token: "secret",
       },
     });
@@ -977,6 +984,35 @@ describe("renderBootstrapScript", () => {
 
     expect(standaloneHarness.fetchCalls).toContainEqual({
       input: "/session-check?token=secret",
+      init: {
+        cache: "no-store",
+        credentials: "same-origin",
+      },
+    });
+  });
+
+  it("ignores stale tokens stored only in localStorage", () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+      importIconSvg: '<svg viewBox="0 0 1 1"></svg>',
+    });
+
+    const harness = createBootstrapHarness({
+      href: "http://127.0.0.1:8787/",
+      localStorageEntries: {
+        __pocodex_token: "secret",
+      },
+    });
+    harness.run(script);
+
+    expect(harness.fetchCalls).toContainEqual({
+      input: "/session-check",
       init: {
         cache: "no-store",
         credentials: "same-origin",
@@ -1235,7 +1271,7 @@ describe("renderBootstrapScript", () => {
     });
 
     expect(fetchCalls.at(-1)).toEqual({
-      input: "/ipc-request",
+      input: "/ipc-request?token=secret",
       init: {
         method: "POST",
         body: '{"method":"ping"}',
@@ -2853,7 +2889,7 @@ describe("renderBootstrapScript", () => {
     expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("expanded");
   });
 
-  it("defaults the mobile sidebar to expanded when no host mode has been stored", async () => {
+  it("does not force a stored expanded mobile sidebar mode onto an already-closed shell", async () => {
     const script = renderBootstrapScript({
       sentryOptions: {
         buildFlavor: "stable",
@@ -2891,7 +2927,172 @@ describe("renderBootstrapScript", () => {
     });
 
     drainTestTimers(harness.timers, 1);
-    expect(harness.dispatchedMessages).toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("does not force the mobile sidebar open when no mode has been stored", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({ mobile: true });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+
+    harness.emitServerEnvelope({
+      type: "bridge_message",
+      message: {
+        type: "persisted-atom-sync",
+        state: {},
+      },
+    });
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    setMobileSidebarClosedState(contentPane, navigation);
+    harness.windowObject.dispatchEvent({ type: "resize" });
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBeNull();
+  });
+
+  it("persists mobile sidebar closes from close-labeled toggle buttons", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    const closeButton = harness.document.createElement("button");
+    closeButton.setAttribute("aria-label", "Close sidebar");
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    harness.document.body.appendChild(closeButton);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    harness.document.dispatchEvent(new TestMouseEvent("click", { target: closeButton }));
+    setMobileSidebarClosedState(contentPane, navigation);
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+  });
+
+  it("persists mobile sidebar toggles sent through the electron bridge", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+
+    await harness.getElectronBridge().sendMessageFromView({
+      type: "toggle-sidebar",
+    });
+    setMobileSidebarClosedState(contentPane, navigation);
+    drainTestTimers(harness.timers);
+
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+  });
+
+  it("does not force a stored expanded mobile sidebar mode back open after the shell closes", async () => {
+    const script = renderBootstrapScript({
+      sentryOptions: {
+        buildFlavor: "stable",
+        appVersion: "1",
+        buildNumber: "123",
+        codexAppSessionId: "session-id",
+      },
+      stylesheetHref: "/pocodex.css",
+    });
+
+    const harness = createBootstrapHarness({
+      mobile: true,
+      localStorageEntries: {
+        "pocodex-sidebar-mode": "expanded",
+      },
+    });
+    const navigation = harness.document.createElement("nav");
+    navigation.setAttribute("role", "navigation");
+    const contentPane = harness.document.createElement("div");
+    contentPane.setAttribute("class", "main-surface");
+    harness.document.body.appendChild(navigation);
+    harness.document.body.appendChild(contentPane);
+    setMobileSidebarOpenState(contentPane, navigation);
+
+    harness.run(script);
+    await flushBootstrapMicrotasks();
+    harness.openSocket();
+    drainTestTimers(harness.timers);
+    harness.dispatchedMessages.length = 0;
+
+    setMobileSidebarClosedState(contentPane, navigation);
+    harness.windowObject.dispatchEvent({ type: "resize" });
+    drainTestTimers(harness.timers);
+
+    expect(harness.dispatchedMessages).not.toContainEqual({ type: "toggle-sidebar" });
+    expect(harness.getLocalStorageValue("pocodex-sidebar-mode")).toBe("collapsed");
   });
 
   it("persists mobile sidebar closes triggered from the content pane", async () => {

--- a/test/codex-desktop-projects.test.ts
+++ b/test/codex-desktop-projects.test.ts
@@ -76,6 +76,42 @@ describe("loadCodexDesktopProjects", () => {
     });
   });
 
+  it("uses desktop project order before saved workspace order", async () => {
+    const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-desktop-state-"));
+    tempDirs.push(tempDirectory);
+
+    const projectA = join(tempDirectory, "project-a");
+    const projectB = join(tempDirectory, "project-b");
+    const projectC = join(tempDirectory, "project-c");
+    await mkdir(projectA, { recursive: true });
+    await mkdir(projectB, { recursive: true });
+    await mkdir(projectC, { recursive: true });
+
+    const statePath = join(tempDirectory, ".codex-global-state.json");
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        "electron-saved-workspace-roots": [projectA, projectB, projectC],
+        "project-order": [projectC, projectA],
+      }),
+      "utf8",
+    );
+
+    await expect(loadCodexDesktopProjects(statePath)).resolves.toMatchObject({
+      projects: [
+        {
+          root: projectC,
+        },
+        {
+          root: projectA,
+        },
+        {
+          root: projectB,
+        },
+      ],
+    });
+  });
+
   it("returns an empty project list when the desktop state file is missing", async () => {
     const tempDirectory = await mkdtemp(join(tmpdir(), "pocodex-desktop-state-"));
     tempDirs.push(tempDirectory);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -227,20 +227,42 @@ describe("PocodexServer", () => {
     await expect(unauthorizedResponse.json()).resolves.toEqual({ ok: false });
   });
 
-  it("allows unauthenticated session checks and websocket attach when no token is configured", async () => {
+  it("rejects session checks and websocket attach when no token is configured", async () => {
     const { server, url } = await createTestServer("");
     servers.push(server);
 
     const okResponse = await fetch(`${url}/session-check`);
     const tokenResponse = await fetch(`${url}/session-check?token=anything`);
 
-    expect(okResponse.status).toBe(200);
-    await expect(okResponse.json()).resolves.toEqual({ ok: true });
+    expect(okResponse.status).toBe(401);
+    await expect(okResponse.json()).resolves.toEqual({ ok: false });
 
-    expect(tokenResponse.status).toBe(200);
-    await expect(tokenResponse.json()).resolves.toEqual({ ok: true });
+    expect(tokenResponse.status).toBe(401);
+    await expect(tokenResponse.json()).resolves.toEqual({ ok: false });
 
-    const socket = await connect(url);
+    await expect(connect(url)).rejects.toThrow("Unexpected server response: 401");
+  });
+
+  it("rejects websocket attach from a mismatched browser origin", async () => {
+    const { server, url } = await createTestServer();
+    servers.push(server);
+    const port = new URL(url).port;
+
+    await expect(
+      connect(url, "secret", {
+        origin: `http://evil.example:${port}`,
+      }),
+    ).rejects.toThrow("Unexpected server response: 403");
+  });
+
+  it("allows websocket attach from the matching origin", async () => {
+    const { server, url } = await createTestServer();
+    servers.push(server);
+
+    const socket = await connect(url, "secret", {
+      origin: url,
+    });
+    expect(socket.readyState).toBe(WebSocket.OPEN);
     socket.close();
   });
 
@@ -693,7 +715,7 @@ describe("PocodexServer", () => {
     const { server, relay, url } = await createTestServer();
     servers.push(server);
 
-    const response = await fetch(`${url}/ipc-request`, {
+    const response = await fetch(`${url}/ipc-request?token=secret`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -724,6 +746,31 @@ describe("PocodexServer", () => {
       result: {
         ok: true,
       },
+    });
+  });
+
+  it("rejects vscode ipc requests without the session token", async () => {
+    const { server, relay, url } = await createTestServer();
+    servers.push(server);
+
+    const response = await fetch(`${url}/ipc-request`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        requestId: "req-1",
+        method: "thread-follower-start-turn",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(relay.ipcPayloads).toEqual([]);
+    await expect(response.json()).resolves.toEqual({
+      requestId: "",
+      type: "response",
+      resultType: "error",
+      error: "Unauthorized IPC request.",
     });
   });
 });
@@ -779,12 +826,20 @@ async function createTestServer(
   };
 }
 
-async function connect(baseUrl: string, token?: string): Promise<WebSocket> {
+async function connect(
+  baseUrl: string,
+  token?: string,
+  options: {
+    origin?: string;
+  } = {},
+): Promise<WebSocket> {
   const url = new URL(`${baseUrl.replace(/^http/, "ws")}/session`);
   if (token) {
     url.searchParams.set("token", token);
   }
-  const socket = new WebSocket(url);
+  const socket = new WebSocket(url, {
+    origin: options.origin,
+  });
   await new Promise<void>((resolve, reject) => {
     socket.once("open", () => resolve());
     socket.once("error", reject);

--- a/test/support/app-server-bridge-test-kit.ts
+++ b/test/support/app-server-bridge-test-kit.ts
@@ -276,11 +276,16 @@ export async function createBridge(
     tempDirs.push(tempDirectory);
     workspaceRootRegistryPath = join(tempDirectory, "workspace-roots.json");
   }
+  let codexHomePath = options.codexHomePath ?? process.env.CODEX_HOME;
+  if (!codexHomePath) {
+    codexHomePath = await mkdtemp(join(tmpdir(), "pocodex-codex-home-"));
+    tempDirs.push(codexHomePath);
+  }
   return AppServerBridge.connect({
     appPath: "/Applications/Codex.app",
     codexCliPath: "/tmp/mock-codex",
     cwd: TEST_WORKSPACE_ROOT,
-    codexHomePath: options.codexHomePath,
+    codexHomePath,
     persistedAtomRegistryPath: options.persistedAtomRegistryPath,
     workspaceRootRegistryPath,
     gitWorkerBridge: options.gitWorkerBridge,


### PR DESCRIPTION
## Summary

* **Safety:** Mandatory token-gated access
* **UI/UX:** Sidebar hiding on mobile, projectless chat startup
* **Workflow:** Workspaces sync with desktop Codex

## Details

Harden Pocodex for trusted LAN/mobile use by requiring token auth, gating IPC requests, checking WebSocket origins, restricting host-side fetches, and scoping file/local-environment access to approved Codex/workspace paths.

Switch browser token persistence to sessionStorage only. Preserve mobile browser usability by importing existing Codex Desktop workspace roots, supporting projectless thread startup, syncing project/thread ordering, and fixing mobile sidebar collapse persistence.

Update safety docs and add regression coverage for auth, bridge fetch restrictions, file access boundaries, workspace import, token storage, and mobile sidebar behaviour.

Validation:
- pnpm test
- pnpm run typecheck
- pnpm run lint
- pnpm run fmt:check