### PR TITLE
fix(app-server-bridge): report active Codex build metadata

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,11 @@ async function main(): Promise<void> {
   }).catch(() => null);
   const relay = await AppServerBridge.connect({
     appPath: options.appPath,
+    codexBuild: {
+      version: bundle.version,
+      buildFlavor: bundle.buildFlavor,
+      buildNumber: bundle.buildNumber,
+    },
     cwd: process.cwd(),
   });
 

--- a/src/lib/app-server-bridge.ts
+++ b/src/lib/app-server-bridge.ts
@@ -7,7 +7,7 @@ import { arch, homedir, platform } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { createInterface } from "node:readline";
 
-import { ensureCodexCliBinary } from "./codex-bundle.js";
+import { ensureCodexCliBinary, type CodexBundle } from "./codex-bundle.js";
 import { deriveCodexHomePath } from "./codex-home.js";
 import {
   DefaultCodexDesktopGitWorkerBridge,
@@ -45,6 +45,7 @@ import {
 interface AppServerBridgeOptions {
   appPath: string;
   cwd: string;
+  codexBuild?: Pick<CodexBundle, "version" | "buildFlavor" | "buildNumber">;
   hostId?: string;
   codexHomePath?: string;
   persistedAtomRegistryPath?: string;
@@ -271,6 +272,7 @@ const LOCAL_UNSUPPORTED_FETCH_BODY = {
 
 export class AppServerBridge extends EventEmitter implements HostBridge {
   private readonly child: ChildProcessWithoutNullStreams;
+  private readonly codexBuild: Pick<CodexBundle, "version" | "buildFlavor" | "buildNumber">;
   private readonly hostId: string;
   private readonly cwd: string;
   private readonly terminalManager: TerminalSessionManager;
@@ -315,6 +317,11 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
 
   private constructor(options: AppServerBridgeOptions) {
     super();
+    this.codexBuild = options.codexBuild ?? {
+      version: "0.1.0",
+      buildFlavor: "pocodex",
+      buildNumber: "0",
+    };
     this.hostId = options.hostId ?? "local";
     this.cwd = options.cwd;
     this.codexHomePath = options.codexHomePath ?? deriveCodexHomePath();
@@ -821,7 +828,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       clientInfo: {
         name: "pocodex",
         title: "Pocodex",
-        version: "0.1.0",
+        version: this.codexBuild.version,
       },
       capabilities: {
         experimentalApi: true,
@@ -1811,11 +1818,7 @@ export class AppServerBridge extends EventEmitter implements HostBridge {
       case "extension-info":
         return {
           status: 200,
-          body: {
-            version: "0.1.0",
-            buildFlavor: "pocodex",
-            buildNumber: "0",
-          },
+          body: this.codexBuild,
         };
       case "is-copilot-api-available":
         return {

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -155,6 +155,11 @@ class ManagedPocodexRuntime extends EventEmitter implements PocodexRuntime {
 
       relay = await AppServerBridge.connect({
         appPath: this.options.appPath,
+        codexBuild: {
+          version: bundle.version,
+          buildFlavor: bundle.buildFlavor,
+          buildNumber: bundle.buildNumber,
+        },
         cwd: this.options.cwd,
       });
 

--- a/test/app-server-bridge-basic.test.ts
+++ b/test/app-server-bridge-basic.test.ts
@@ -20,7 +20,13 @@ import {
 
 describeAppServerBridge(({ children }) => {
   it("initializes the codex app-server and forwards MCP traffic", async () => {
-    const bridge = await createBridge(children);
+    const bridge = await createBridge(children, {
+      codexBuild: {
+        version: "26.313.5234.0",
+        buildFlavor: "stable",
+        buildNumber: "5234",
+      },
+    });
 
     const emittedMessages: unknown[] = [];
     bridge.on("bridge_message", (message) => {
@@ -36,6 +42,7 @@ describeAppServerBridge(({ children }) => {
     const written = child?.writes ?? "";
     expect(written).toContain('"method":"initialize"');
     expect(written).toContain('"method":"initialized"');
+    expect(written).toContain('"version":"26.313.5234.0"');
 
     await bridge.forwardBridgeMessage({
       type: "mcp-request",

--- a/test/app-server-bridge-host-data.test.ts
+++ b/test/app-server-bridge-host-data.test.ts
@@ -131,6 +131,39 @@ describeAppServerBridge(({ children }) => {
     await bridge.close();
   });
 
+  it("reports the active Codex desktop build from extension-info", async () => {
+    const bridge = await createBridge(children, {
+      codexBuild: {
+        version: "26.313.5234.0",
+        buildFlavor: "stable",
+        buildNumber: "5234",
+      },
+    });
+    const emittedMessages: unknown[] = [];
+    bridge.on("bridge_message", (message) => {
+      emittedMessages.push(message);
+    });
+
+    await bridge.forwardBridgeMessage({
+      type: "fetch",
+      requestId: "fetch-extension-info",
+      method: "POST",
+      url: "vscode://codex/extension-info",
+    });
+
+    await waitForCondition(() =>
+      Boolean(getFetchResponse(emittedMessages, "fetch-extension-info")),
+    );
+
+    expect(getFetchJsonBody(emittedMessages, "fetch-extension-info")).toEqual({
+      version: "26.313.5234.0",
+      buildFlavor: "stable",
+      buildNumber: "5234",
+    });
+
+    await bridge.close();
+  });
+
   it("generates thread titles for host fetch requests", async () => {
     const bridge = await createBridge(children);
     const emittedMessages: unknown[] = [];

--- a/test/codex-bundle.test.ts
+++ b/test/codex-bundle.test.ts
@@ -6,9 +6,13 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const asarMock = vi.hoisted(() => ({
-  extractFile: vi.fn((_appAsarPath: string, _filename: string) => Buffer.alloc(0)),
-  listPackage: vi.fn((_appAsarPath: string, _options: { isPack: boolean }) => [] as string[]),
-  statFile: vi.fn(),
+  extractFile: vi.fn<typeof import("@electron/asar").extractFile>(
+    (_appAsarPath: string, _filename: string) => Buffer.alloc(0),
+  ),
+  listPackage: vi.fn<typeof import("@electron/asar").listPackage>(
+    (_appAsarPath: string, _options: { isPack: boolean }) => [] as string[],
+  ),
+  statFile: vi.fn<typeof import("@electron/asar").statFile>(),
 }));
 vi.mock("@electron/asar", () => asarMock);
 

--- a/test/codex-home.test.ts
+++ b/test/codex-home.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { deriveCodexHomePath } from "../src/lib/codex-home.js";
 
 vi.mock("node:child_process", () => ({
-  execFileSync: vi.fn(),
+  execFileSync: vi.fn<typeof import("node:child_process").execFileSync>(),
 }));
 
 describe("deriveCodexHomePath", () => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -3,9 +3,9 @@ import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const runtimeMocks = vi.hoisted(() => ({
-  connect: vi.fn(),
-  getServeUrls: vi.fn(),
-  loadCodexBundle: vi.fn(),
+  connect: vi.fn<() => Promise<unknown>>(),
+  getServeUrls: vi.fn<(...args: unknown[]) => unknown>(),
+  loadCodexBundle: vi.fn<() => Promise<unknown>>(),
   serverInstances: [] as Array<{
     close: ReturnType<typeof vi.fn>;
     getAddress: ReturnType<typeof vi.fn>;
@@ -31,14 +31,14 @@ vi.mock("../src/lib/serve-url.js", () => ({
 
 vi.mock("../src/lib/server.js", () => ({
   PocodexServer: class {
-    close = vi.fn(async () => {});
-    getAddress = vi.fn(() => ({
+    close = vi.fn<() => Promise<void>>(async () => {});
+    getAddress = vi.fn<() => { address: string; family: string; port: number }>(() => ({
       address: "127.0.0.1",
       family: "IPv4",
       port: 4321,
     }));
-    listen = vi.fn(async () => {});
-    notifyStylesheetReload = vi.fn();
+    listen = vi.fn<() => Promise<void>>(async () => {});
+    notifyStylesheetReload = vi.fn<(versionTag: string) => void>();
 
     constructor(public readonly options: unknown) {
       runtimeMocks.serverInstances.push(this);
@@ -49,11 +49,13 @@ vi.mock("../src/lib/server.js", () => ({
 import { createPocodexRuntime } from "../src/index.js";
 
 class TestRelay extends EventEmitter {
-  close = vi.fn(async () => {});
-  forwardBridgeMessage = vi.fn(async () => {});
-  sendWorkerMessage = vi.fn(async () => {});
-  subscribeWorker = vi.fn(async () => {});
-  unsubscribeWorker = vi.fn(async () => {});
+  close = vi.fn<() => Promise<void>>(async () => {});
+  forwardBridgeMessage = vi.fn<(message: unknown) => Promise<void>>(async () => {});
+  sendWorkerMessage = vi.fn<(workerName: string, message: unknown) => Promise<void>>(
+    async () => {},
+  );
+  subscribeWorker = vi.fn<(workerName: string) => Promise<void>>(async () => {});
+  unsubscribeWorker = vi.fn<(workerName: string) => Promise<void>>(async () => {});
 }
 
 describe("createPocodexRuntime", () => {
@@ -247,7 +249,9 @@ function createBundle(version: string, appPath = "/Applications/Codex.app") {
     appPath,
     buildFlavor: "prod",
     buildNumber: "123",
-    readIndexHtml: vi.fn(async () => "<!doctype html><html><body></body></html>"),
+    readIndexHtml: vi.fn<() => Promise<string>>(
+      async () => "<!doctype html><html><body></body></html>",
+    ),
     version,
     webviewRoot: "/tmp/pocodex-webview",
   };

--- a/test/support/app-server-bridge-test-kit.ts
+++ b/test/support/app-server-bridge-test-kit.ts
@@ -10,12 +10,12 @@ vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
-    spawn: vi.fn(),
+    spawn: vi.fn<typeof import("node:child_process").spawn>(),
   };
 });
 
 vi.mock("node-pty", () => ({
-  spawn: vi.fn(),
+  spawn: vi.fn<typeof import("node-pty").spawn>(),
 }));
 
 export const mockLocalThreadList = { data: [] as unknown[] };
@@ -250,6 +250,11 @@ export function describeAppServerBridge(
 export async function createBridge(
   children: MockChildProcess[],
   options: {
+    codexBuild?: {
+      version: string;
+      buildFlavor: string;
+      buildNumber: string;
+    };
     codexHomePath?: string;
     persistedAtomRegistryPath?: string;
     workspaceRootRegistryPath?: string;
@@ -278,6 +283,7 @@ export async function createBridge(
   }
   return AppServerBridge.connect({
     appPath: "/Applications/Codex.app",
+    codexBuild: options.codexBuild,
     codexCliPath: "/tmp/mock-codex",
     cwd: TEST_WORKSPACE_ROOT,
     codexHomePath: options.codexHomePath,


### PR DESCRIPTION
Pass the installed Codex version and build metadata through Pocodex so the latest webview no longer shows a false update-required prompt.

Also make the touched Vitest mocks explicit enough for the pre-commit lint rule to pass.

This fixes "Update required" popup in https://github.com/davej/pocodex/issues/26.